### PR TITLE
Update EditingCommandHandler.cs

### DIFF
--- a/ICSharpCode.AvalonEdit/Editing/EditingCommandHandler.cs
+++ b/ICSharpCode.AvalonEdit/Editing/EditingCommandHandler.cs
@@ -193,107 +193,124 @@ namespace ICSharpCode.AvalonEdit.Editing
 		}
 		#endregion
 		
-		#region Tab
-		static void OnTab(object target, ExecutedRoutedEventArgs args)
-      {
-         TextArea textArea = GetTextArea(target);
-         if (textArea != null && textArea.Document != null)
-         {
-            using (textArea.Document.RunUpdate())
-            {
-               if (textArea.Selection.IsMultiline)
-               {
-                  var segment = textArea.Selection.SurroundingSegment;
-                  DocumentLine start = textArea.Document.GetLineByOffset(segment.Offset);
-                  DocumentLine end = textArea.Document.GetLineByOffset(segment.EndOffset);
-                  // don't include the last line if no characters on it are selected
-                  if (start != end && end.Offset == segment.EndOffset)
-                     end = end.PreviousLine;
-                  DocumentLine current = start;
-
-                  bool isInsertTab = textArea.Selection.Segments.Count() > 1;
-                  var i = textArea.Selection.Segments.GetEnumerator();
-                  int j = 0;
-                  int idenLen = textArea.Options.ConvertTabsToSpaces ? textArea.Options.IndentationSize : 1;
-
-                  //Restore selection manually
-                  var startSel = textArea.Selection.StartPosition;
-                  var endSel = textArea.Selection.EndPosition;
-                  startSel.Column += idenLen;
-                  endSel.Column += idenLen;
-                  startSel.VisualColumn += textArea.Options.IndentationSize;
-                  endSel.VisualColumn += textArea.Options.IndentationSize;
-
-                  while (true)
-                  {
-                     int offset = 0;
-                     if (isInsertTab)
-                     {
-                        i.MoveNext();
-                        offset = i.Current.StartOffset + j * idenLen;
-                        j++;
-                     }
-                     else
-                        offset = current.Offset;
-                     if (textArea.ReadOnlySectionProvider.CanInsert(offset))
-                     {
-                        textArea.Document.Insert(offset, textArea.Options.IndentationString);
-                     }
-                     if (current == end)
-                        break;
-                     current = current.NextLine;
-                  }
-                  if (textArea.Selection is RectangleSelection)
-                     textArea.Selection = new RectangleSelection(textArea, startSel, endSel);
-               }
-               else
-               {
-                  string indentationString = textArea.Options.GetIndentationString(textArea.Caret.Column);
-                  textArea.ReplaceSelectionWithText(indentationString);
-               }
-            }
-            textArea.Caret.BringCaretToView();
-            args.Handled = true;
-
-         }
-      }
-
-      private static bool TryDeleteIdentationFragment(TextArea textArea, int offset)
-      {
-         ISegment s = TextUtilities.GetSingleIndentationSegment(textArea.Document, offset, textArea.Options.IndentationSize);
-         if (s != null && s.Length > 0)
-         {
-            s = textArea.GetDeletableSegments(s).FirstOrDefault();
-            if (s != null && s.Length > 0)
-            {
-               textArea.Document.Remove(s.Offset, s.Length);
-               return true;
-            }
-         }
-         return false;
-      }
-
-      static void OnShiftTab(object target, ExecutedRoutedEventArgs args)
-      {
-         TextArea textArea = GetTextArea(target);
-         if (textArea.Selection is RectangleSelection)
-         {
-            var offsetCoerce = 0;
-            var idenLen = textArea.Options.ConvertTabsToSpaces ? textArea.Options.IndentationSize : 1;
-            textArea.Document.UndoStack.StartUndoGroup("Multicarret identation delete");
-            foreach (var segment in textArea.Selection.Segments)
-            {
-               var remPoint = segment.StartOffset - idenLen - offsetCoerce;
-               if (TryDeleteIdentationFragment(textArea, remPoint))
-                  offsetCoerce += idenLen;
-            }
-            textArea.Document.UndoStack.EndUndoGroup();
-         }
-         else
-         {
-            TransformSelectedLines((area, line) => TryDeleteIdentationFragment(area, line.Offset), target, args, DefaultSegmentType.CurrentLine);
-         }
-      }
+	        #region Tab
+	        static void OnTab(object target, ExecutedRoutedEventArgs args)
+	        {
+	           TextArea textArea = GetTextArea(target);
+	           if (textArea != null && textArea.Document != null)
+	           {
+	              using (textArea.Document.RunUpdate())
+	              {
+	                 if (textArea.Selection.IsMultiline)
+	                 {
+	                    var segment = textArea.Selection.SurroundingSegment;
+	                    DocumentLine start = textArea.Document.GetLineByOffset(segment.Offset);
+	                    DocumentLine end = textArea.Document.GetLineByOffset(segment.EndOffset);
+	                    // don't include the last line if no characters on it are selected
+	                    //if (start != end && end.Offset == segment.EndOffset)
+	                    //   end = end.PreviousLine;
+	                    DocumentLine current = start;
+	  
+	                    bool isInsertTab = textArea.Selection.Segments.Count() > 1;
+	                    var i = textArea.Selection.Segments.GetEnumerator();
+	                    int j = 0;
+	                    int idenLen = textArea.Options.ConvertTabsToSpaces ? textArea.Options.IndentationSize : 1;
+	  
+	                    //Restore selection manually
+	                    var startSel = textArea.Selection.StartPosition;
+	                    var endSel = textArea.Selection.EndPosition;
+	                    startSel.Column += idenLen;
+	                    endSel.Column += idenLen;
+	                    startSel.VisualColumn += textArea.Options.IndentationSize;
+	                    endSel.VisualColumn += textArea.Options.IndentationSize;
+	  
+	                    while (true)
+	                    {
+	                       int offset = 0;
+	                       if (isInsertTab)
+	                       {
+	                          i.MoveNext();
+	                          offset = i.Current.StartOffset + j * idenLen;
+	                          j++;
+	                       }
+	                       else
+	                          offset = current.Offset;
+	                       if (textArea.ReadOnlySectionProvider.CanInsert(offset))
+	                       {
+	                          textArea.Document.Insert(offset, textArea.Options.IndentationString);
+	                       }
+	                       if (current == end)
+	                          break;
+	                       current = current.NextLine;
+	                    }
+	                    if (textArea.Selection is RectangleSelection)
+	                       textArea.Selection = new RectangleSelection(textArea, startSel, endSel);
+	                 }
+	                 else
+	                 {
+	                    string indentationString = textArea.Options.GetIndentationString(textArea.Caret.Column);
+	                    textArea.ReplaceSelectionWithText(indentationString);
+	                 }
+	              }
+	              textArea.Caret.BringCaretToView();
+	              args.Handled = true;
+	  
+	           }
+	        }
+	  
+	        private static bool TryDeleteIdentationFragment(TextArea textArea, int offset)
+	        {
+	           ISegment s = TextUtilities.GetSingleIndentationSegment(textArea.Document, offset, textArea.Options.IndentationSize);
+	           if (s != null && s.Length > 0)
+	           {
+	              s = textArea.GetDeletableSegments(s).FirstOrDefault();
+	              if (s != null && s.Length > 0)
+	              {
+	                 textArea.Document.Remove(s.Offset, s.Length);
+	                 return true;
+	              }
+	           }
+	           return false;
+	        }
+	  
+	  	   static void OnShiftTab(object target, ExecutedRoutedEventArgs args)
+	        {
+	           TextArea textArea = GetTextArea(target);
+	           
+	           var idenLen = textArea.Options.ConvertTabsToSpaces ? textArea.Options.IndentationSize : 1;
+	           if (textArea.Selection is RectangleSelection)
+	           {
+	              var offsetCoerce = 0;
+	              textArea.Document.UndoStack.StartUndoGroup("Multicarret identation delete");
+	              foreach (var segment in textArea.Selection.Segments)
+	              {
+	                 var remPoint = segment.StartOffset - idenLen - offsetCoerce;
+	                 if (remPoint < 0 || remPoint > textArea.Document.TextLength)
+	                 {
+	                    textArea.Document.UndoStack.EndUndoGroup();
+	                    return;
+	                 }
+	                 if (TryDeleteIdentationFragment(textArea, remPoint))
+	                    offsetCoerce += idenLen;
+	              }
+	              textArea.Document.UndoStack.EndUndoGroup();
+	           }
+	           else
+	           {
+	              if (textArea.Selection.IsEmpty ||
+	                  textArea.Selection.IsMultiline)
+	              {
+	                 var remPoint = textArea.Caret.Offset - idenLen;
+	                 if (remPoint < 0 || remPoint > textArea.Document.TextLength)
+	                    return;
+	                 TryDeleteIdentationFragment(textArea, remPoint);
+	              }
+	              else
+	              {
+	                 TransformSelectedLines((area, line) => TryDeleteIdentationFragment(area, line.Offset), target, args, DefaultSegmentType.CurrentLine);
+	              }
+	           }
+	        }
 		#endregion
 		
 		#region Delete
@@ -310,10 +327,11 @@ namespace ICSharpCode.AvalonEdit.Editing
                      foreach (var s in textArea.Selection.Segments.Reverse())
 						   {
 						      int delOffset = s.StartOffset + caretMovementOffset;
-                        if (caretMovement == CaretMovementType.Backspace &&
-                            (delOffset < 0 || s.StartVisualColumn == 0))
+                        if (caretMovement == CaretMovementType.Backspace && (delOffset < 0 || s.StartVisualColumn == 0) ||
+                            caretMovement == CaretMovementType.CharRight &&
+                               (delOffset >= textArea.Document.TextLength || s.EndOffset >= textArea.Document.GetLineByOffset(delOffset).EndOffset))
                            continue;
-                        textArea.Document.Remove(s.StartOffset + caretMovementOffset, 1);
+                        textArea.Document.Remove(delOffset, 1);
 						   }
                      textArea.Document.UndoStack.EndUndoGroup();
                      if (caretMovement == CaretMovementType.Backspace)

--- a/ICSharpCode.AvalonEdit/Editing/EditingCommandHandler.cs
+++ b/ICSharpCode.AvalonEdit/Editing/EditingCommandHandler.cs
@@ -195,97 +195,105 @@ namespace ICSharpCode.AvalonEdit.Editing
 		
 		#region Tab
 		static void OnTab(object target, ExecutedRoutedEventArgs args)
-		{
-		   TextArea textArea = GetTextArea(target);
-		   if (textArea != null && textArea.Document != null)
-		   {
-		      using (textArea.Document.RunUpdate())
-		      {
-		         if (textArea.Selection.IsMultiline)
-		         {
-		            var segment = textArea.Selection.SurroundingSegment;
-		            DocumentLine start = textArea.Document.GetLineByOffset(segment.Offset);
-		            DocumentLine end = textArea.Document.GetLineByOffset(segment.EndOffset);
-		            // don't include the last line if no characters on it are selected
-		            if (start != end && end.Offset == segment.EndOffset)
-		               end = end.PreviousLine;
-		            DocumentLine current = star      
-		            bool isInsertTab = textArea.Selection.Segments.Count() > 1;
-		            var i = textArea.Selection.Segments.GetEnumerator();
-		            int j = 0;
-		            int idenLen = textArea.Options.ConvertTabsToSpaces ? textArea.Options.IndentationSize :       
-		            //Restore selection manually
-		            var startSel = textArea.Selection.StartPosition;
-		            var endSel = textArea.Selection.EndPosition;
-		            startSel.Column += idenLen;
-		            endSel.Column += idenLen;
-		            startSel.VisualColumn += textArea.Options.IndentationSize;
-		            endSel.VisualColumn += textArea.Options.IndentationSiz      
-		            while (true)
-		            {
-		               int offset = 0;
-		               if (isInsertTab)
-		               {
-		                  i.MoveNext();
-		                  offset = i.Current.StartOffset + j * idenLen;
-		                  j++;
-		               }
-		               else
-		                  offset = current.Offset;
-		               if (textArea.ReadOnlySectionProvider.CanInsert(offset))
-		               {
-		                  textArea.Document.Insert(offset, textArea.Options.IndentationString);
-		               }
-		               if (current == end)
-		                  break;
-		               current = current.NextLine;
-		            }
-		            if (textArea.Selection is RectangleSelection)
-		               textArea.Selection = new RectangleSelection(textArea, startSel, endSel);
-		         }
-		         else
-		         {
-		            string indentationString = textArea.Options.GetIndentationString(textArea.Caret.Column);
-		            textArea.ReplaceSelectionWithText(indentationString);
-		         }
-		      }
-		      textArea.Caret.BringCaretToView();
-		      args.Handled = tru      
-		   }
-		     
-		private static bool TryDeleteIdentationFragment(TextArea textArea, int offset)
-		{
-		   ISegment s = TextUtilities.GetSingleIndentationSegment(textArea.Document, offset, textArea.Options.IndentationSize);
-		   if (s != null && s.Length > 0)
-		   {
-		      s = textArea.GetDeletableSegments(s).FirstOrDefault();
-		      if (s != null && s.Length > 0)
-		      {
-		         textArea.Document.Remove(s.Offset, s.Length);
-		         return true;
-		      }
-		   }
-		   return false;
-		     
-		static void OnShiftTab(object target, ExecutedRoutedEventArgs args)
-		{
-		   TextArea textArea = GetTextArea(target);
-		   if (textArea.Selection is RectangleSelection)
-		   {
-		      var offsetCoerce = 0;
-		      var idenLen = textArea.Options.ConvertTabsToSpaces ? textArea.Options.IndentationSize : 1;
-		      foreach (var segment in textArea.Selection.Segments)
-		      {
-		         var remPoint = segment.StartOffset - idenLen - offsetCoerce;
-		         if (TryDeleteIdentationFragment(textArea, remPoint))
-		            offsetCoerce += idenLen;
-		      }
-		   }
-		   else
-		   {
-		      TransformSelectedLines((area, line) => TryDeleteIdentationFragment(area, line.Offset), target, args, DefaultSegmentType.CurrentLine);
-		   }
-		}
+      {
+         TextArea textArea = GetTextArea(target);
+         if (textArea != null && textArea.Document != null)
+         {
+            using (textArea.Document.RunUpdate())
+            {
+               if (textArea.Selection.IsMultiline)
+               {
+                  var segment = textArea.Selection.SurroundingSegment;
+                  DocumentLine start = textArea.Document.GetLineByOffset(segment.Offset);
+                  DocumentLine end = textArea.Document.GetLineByOffset(segment.EndOffset);
+                  // don't include the last line if no characters on it are selected
+                  if (start != end && end.Offset == segment.EndOffset)
+                     end = end.PreviousLine;
+                  DocumentLine current = start;
+
+                  bool isInsertTab = textArea.Selection.Segments.Count() > 1;
+                  var i = textArea.Selection.Segments.GetEnumerator();
+                  int j = 0;
+                  int idenLen = textArea.Options.ConvertTabsToSpaces ? textArea.Options.IndentationSize : 1;
+
+                  //Restore selection manually
+                  var startSel = textArea.Selection.StartPosition;
+                  var endSel = textArea.Selection.EndPosition;
+                  startSel.Column += idenLen;
+                  endSel.Column += idenLen;
+                  startSel.VisualColumn += textArea.Options.IndentationSize;
+                  endSel.VisualColumn += textArea.Options.IndentationSize;
+
+                  while (true)
+                  {
+                     int offset = 0;
+                     if (isInsertTab)
+                     {
+                        i.MoveNext();
+                        offset = i.Current.StartOffset + j * idenLen;
+                        j++;
+                     }
+                     else
+                        offset = current.Offset;
+                     if (textArea.ReadOnlySectionProvider.CanInsert(offset))
+                     {
+                        textArea.Document.Insert(offset, textArea.Options.IndentationString);
+                     }
+                     if (current == end)
+                        break;
+                     current = current.NextLine;
+                  }
+                  if (textArea.Selection is RectangleSelection)
+                     textArea.Selection = new RectangleSelection(textArea, startSel, endSel);
+               }
+               else
+               {
+                  string indentationString = textArea.Options.GetIndentationString(textArea.Caret.Column);
+                  textArea.ReplaceSelectionWithText(indentationString);
+               }
+            }
+            textArea.Caret.BringCaretToView();
+            args.Handled = true;
+
+         }
+      }
+
+      private static bool TryDeleteIdentationFragment(TextArea textArea, int offset)
+      {
+         ISegment s = TextUtilities.GetSingleIndentationSegment(textArea.Document, offset, textArea.Options.IndentationSize);
+         if (s != null && s.Length > 0)
+         {
+            s = textArea.GetDeletableSegments(s).FirstOrDefault();
+            if (s != null && s.Length > 0)
+            {
+               textArea.Document.Remove(s.Offset, s.Length);
+               return true;
+            }
+         }
+         return false;
+      }
+
+      static void OnShiftTab(object target, ExecutedRoutedEventArgs args)
+      {
+         TextArea textArea = GetTextArea(target);
+         if (textArea.Selection is RectangleSelection)
+         {
+            var offsetCoerce = 0;
+            var idenLen = textArea.Options.ConvertTabsToSpaces ? textArea.Options.IndentationSize : 1;
+            textArea.Document.UndoStack.StartUndoGroup("Multicarret identation delete");
+            foreach (var segment in textArea.Selection.Segments)
+            {
+               var remPoint = segment.StartOffset - idenLen - offsetCoerce;
+               if (TryDeleteIdentationFragment(textArea, remPoint))
+                  offsetCoerce += idenLen;
+            }
+            textArea.Document.UndoStack.EndUndoGroup();
+         }
+         else
+         {
+            TransformSelectedLines((area, line) => TryDeleteIdentationFragment(area, line.Offset), target, args, DefaultSegmentType.CurrentLine);
+         }
+      }
 		#endregion
 		
 		#region Delete
@@ -295,21 +303,49 @@ namespace ICSharpCode.AvalonEdit.Editing
 				TextArea textArea = GetTextArea(target);
 				if (textArea != null && textArea.Document != null) {
 					if (textArea.Selection.IsEmpty) {
-						TextViewPosition startPos = textArea.Caret.Position;
-						bool enableVirtualSpace = textArea.Options.EnableVirtualSpace;
-						// When pressing delete; don't move the caret further into virtual space - instead delete the newline
-						if (caretMovement == CaretMovementType.CharRight)
-							enableVirtualSpace = false;
-						double desiredXPos = textArea.Caret.DesiredXPos;
-						TextViewPosition endPos = CaretNavigationCommandHandler.GetNewCaretPosition(
-							textArea.TextView, startPos, caretMovement, enableVirtualSpace, ref desiredXPos);
-						// GetNewCaretPosition may return (0,0) as new position,
-						// thus we need to validate endPos before using it in the selection.
-						if (endPos.Line < 1 || endPos.Column < 1)
-							endPos = new TextViewPosition(Math.Max(endPos.Line, 1), Math.Max(endPos.Column, 1));
-						// Don't select the text to be deleted; just reuse the ReplaceSelectionWithText logic
-						var sel = new SimpleSelection(textArea, startPos, endPos);
-						sel.ReplaceSelectionWithText(string.Empty);
+						if (textArea.Selection is RectangleSelection)
+						{
+						   int caretMovementOffset = caretMovement == CaretMovementType.Backspace? -1 : 0;
+						   textArea.Document.UndoStack.StartUndoGroup("Multicarret delete");
+                     foreach (var s in textArea.Selection.Segments.Reverse())
+						   {
+						      int delOffset = s.StartOffset + caretMovementOffset;
+                        if (caretMovement == CaretMovementType.Backspace &&
+                            (delOffset < 0 || s.StartVisualColumn == 0))
+                           continue;
+                        textArea.Document.Remove(s.StartOffset + caretMovementOffset, 1);
+						   }
+                     textArea.Document.UndoStack.EndUndoGroup();
+                     if (caretMovement == CaretMovementType.Backspace)
+                     {
+                        var startSel = textArea.Selection.StartPosition;
+                        var endSel = textArea.Selection.EndPosition;
+                        if (startSel.Column != 0)
+                        {
+                           endSel.Column -= 1;
+                           endSel.VisualColumn -= 1;
+                        }
+                        textArea.Selection = new RectangleSelection(textArea, startSel, endSel);
+                     }
+						}
+                  else
+						{
+                     TextViewPosition startPos = textArea.Caret.Position;
+                     bool enableVirtualSpace = textArea.Options.EnableVirtualSpace;
+                     // When pressing delete; don't move the caret further into virtual space - instead delete the newline
+                     if (caretMovement == CaretMovementType.CharRight)
+                        enableVirtualSpace = false;
+                     double desiredXPos = textArea.Caret.DesiredXPos;
+                     TextViewPosition endPos = CaretNavigationCommandHandler.GetNewCaretPosition(
+                        textArea.TextView, startPos, caretMovement, enableVirtualSpace, ref desiredXPos);
+                     // GetNewCaretPosition may return (0,0) as new position,
+                     // thus we need to validate endPos before using it in the selection.
+                     if (endPos.Line < 1 || endPos.Column < 1)
+                        endPos = new TextViewPosition(Math.Max(endPos.Line, 1), Math.Max(endPos.Column, 1));
+                     // Don't select the text to be deleted; just reuse the ReplaceSelectionWithText logic
+                     var sel = new SimpleSelection(textArea, startPos, endPos);
+                     sel.ReplaceSelectionWithText(string.Empty);
+						}
 					} else {
 						textArea.RemoveSelectedText();
 					}

--- a/ICSharpCode.AvalonEdit/Editing/EditingCommandHandler.cs
+++ b/ICSharpCode.AvalonEdit/Editing/EditingCommandHandler.cs
@@ -297,7 +297,7 @@ namespace ICSharpCode.AvalonEdit.Editing
 	           else
 	           {
 	              if (textArea.Selection.IsEmpty ||
-	                  textArea.Selection.IsMultiline)
+	                  !textArea.Selection.IsMultiline)
 	              {
 	                 var remPoint = textArea.Caret.Offset - idenLen;
 	                 if (remPoint < 0 || remPoint > textArea.Document.TextLength)

--- a/ICSharpCode.AvalonEdit/Editing/EditingCommandHandler.cs
+++ b/ICSharpCode.AvalonEdit/Editing/EditingCommandHandler.cs
@@ -248,8 +248,7 @@ namespace ICSharpCode.AvalonEdit.Editing
 	                 }
 	                 else
 	                 {
-	                    string indentationString = textArea.Options.GetIndentationString(textArea.Caret.Column);
-	                    textArea.ReplaceSelectionWithText(indentationString);
+	                    textArea.ReplaceSelectionWithText(textArea.Options.IndentationString);
 	                 }
 	              }
 	              textArea.Caret.BringCaretToView();


### PR DESCRIPTION
OnTab and OnShiftTab doesn't handle Rectangle selection correctly (multicarret):
It is a customary behavior to insert/delete identation segments right before multicarret at each line, while currently AvalonEdit always inserts identation at the line's beginnings. Usuall selection (solid single/multi line) behaves in an old way.
My fix is a little bit awkward - i didn't dive into code to find out why rectangle selection becomes incorrect, I simply recreate it in OnTab

Upd:
https://github.com/icsharpcode/AvalonEdit/issues/22 fix
Somewhat straightforward, but i didn't get the whole "VirtualSpace" concept and how it should be used.
"var sel = new SimpleSelection(...);" it totally wrong anyway...

P.S. I am sorry for corrupted formatting. No idea how to fix this from web-interface unless manually.
I hope you could use your IDE's autoformat feature with nessecary for GitHub parameters if you have an established Git repositary client