### PR TITLE
Added tab replacement to OnPaste in EditingCommandHandler

### DIFF
--- a/ICSharpCode.AvalonEdit/Editing/EditingCommandHandler.cs
+++ b/ICSharpCode.AvalonEdit/Editing/EditingCommandHandler.cs
@@ -450,6 +450,7 @@ namespace ICSharpCode.AvalonEdit.Editing
 					else
 						return; // no text data format
 					text = TextUtilities.NormalizeNewLines(text, newLine);
+					text = textArea.Options.ConvertTabsToSpaces ? text.Replace("\t", new String(' ', textArea.Options.IndentationSize)) : text;
 				} catch (OutOfMemoryException) {
 					// may happen when trying to paste a huge string
 					return;


### PR DESCRIPTION
This is a fix for #25.

The proposed change causes pasted tabs to be replaced with the number of spaces specified by **IndentationSize** when the **ConvertTabsToSpaces** option is enabled.