### PR TITLE
Fix #12: Behavior of 'end' key is incorrect if 'show spaces' is not enabled

### DIFF
--- a/ICSharpCode.AvalonEdit/Editing/CaretNavigationCommandHandler.cs
+++ b/ICSharpCode.AvalonEdit/Editing/CaretNavigationCommandHandler.cs
@@ -259,7 +259,7 @@ namespace ICSharpCode.AvalonEdit.Editing
 		
 		static TextViewPosition GetEndOfLineCaretPosition(VisualLine visualLine, TextLine textLine)
 		{
-			int newVC = visualLine.GetTextLineVisualStartColumn(textLine) + textLine.Length - textLine.TrailingWhitespaceLength;
+			int newVC = visualLine.GetTextLineVisualStartColumn(textLine) + textLine.Length - 1;
 			TextViewPosition pos = visualLine.GetTextViewPosition(newVC);
 			pos.IsAtEndOfLine = true;
 			return pos;


### PR DESCRIPTION
This change fixes the inconsistent 'end' key behavior described in #12 and makes it so that the caret always goes to the end of the line, including any whitespace.