### PR TITLE
Fix #40 cursor left should not go to prev line if virtual space

### DIFF
--- a/ICSharpCode.AvalonEdit/Editing/CaretNavigationCommandHandler.cs
+++ b/ICSharpCode.AvalonEdit/Editing/CaretNavigationCommandHandler.cs
@@ -295,6 +295,8 @@ namespace ICSharpCode.AvalonEdit.Editing
 			if (pos >= 0) {
 				return visualLine.GetTextViewPosition(pos);
 			} else {
+				if(enableVirtualSpace && mode == CaretPositioningMode.Normal) 
+					return caretPosition;
 				// move to end of previous line
 				DocumentLine previousDocumentLine = visualLine.FirstDocumentLine.PreviousLine;
 				if (previousDocumentLine != null) {

--- a/ICSharpCode.AvalonEdit/Editing/CaretNavigationCommandHandler.cs
+++ b/ICSharpCode.AvalonEdit/Editing/CaretNavigationCommandHandler.cs
@@ -213,6 +213,9 @@ namespace ICSharpCode.AvalonEdit.Editing
 			switch (direction) {
 				case CaretMovementType.CharLeft:
 					desiredXPos = double.NaN;
+					// do not move caret to previous line in virtual space
+					if (caretPosition.VisualColumn == 0 && enableVirtualSpace)
+						return caretPosition;
 					return GetPrevCaretPosition(textView, caretPosition, visualLine, CaretPositioningMode.Normal, enableVirtualSpace);
 				case CaretMovementType.Backspace:
 					desiredXPos = double.NaN;
@@ -295,8 +298,6 @@ namespace ICSharpCode.AvalonEdit.Editing
 			if (pos >= 0) {
 				return visualLine.GetTextViewPosition(pos);
 			} else {
-				if(enableVirtualSpace && mode == CaretPositioningMode.Normal) 
-					return caretPosition;
 				// move to end of previous line
 				DocumentLine previousDocumentLine = visualLine.FirstDocumentLine.PreviousLine;
 				if (previousDocumentLine != null) {


### PR DESCRIPTION
Fixes #40 when caret is at column 0, moving left doesn't go to previous line if virtual space is enabled. 