### PR TITLE
Fix #37 moving caret to start or end of selection

### DIFF
--- a/ICSharpCode.AvalonEdit/Editing/SelectionMouseHandler.cs
+++ b/ICSharpCode.AvalonEdit/Editing/SelectionMouseHandler.cs
@@ -644,11 +644,11 @@ namespace ICSharpCode.AvalonEdit.Editing
 					textArea.Selection = Selection.Create(textArea,
 					                                      Math.Min(newWord.Offset, startWord.Offset),
 					                                      Math.Max(newWord.EndOffset, startWord.EndOffset));
-					// Set caret offset, but limit the caret to stay inside the selection.
-					// in whole-word selection, it's otherwise possible that we get the caret outside the
-					// selection - but the TextArea doesn't like that and will reset the selection, causing
-					// flickering.
-					SetCaretOffsetToMousePosition(e, textArea.Selection.SurroundingSegment);
+					// moves caret to start or end of selection
+					if( newWord.Offset < startWord.Offset) 
+						textArea.Caret.Offset = newWord.Offset;
+					else 
+						textArea.Caret.Offset = Math.Max(newWord.EndOffset, startWord.EndOffset);
 				}
 			}
 			textArea.Caret.BringCaretToView(5.0);


### PR DESCRIPTION
Selecting a word (double click) now causes the caret to move to the end of the selection. 

If selection is done backward (ctrl + mouse) the caret is moved to the start of the selection. 

Selecting the whole line (triple click) moves the caret to the end.