### PR TITLE
Fix #43 Added alternate cut, copy, paste shortcuts

### DIFF
--- a/ICSharpCode.AvalonEdit/AvalonEditCommands.cs
+++ b/ICSharpCode.AvalonEdit/AvalonEditCommands.cs
@@ -27,6 +27,12 @@ namespace ICSharpCode.AvalonEdit
 	public static class AvalonEditCommands
 	{
 		/// <summary>
+		/// Toggles Overstrike mode
+		/// The default shortcut is Ins.
+		/// </summary>
+		public static readonly RoutedCommand ToggleOverstrike = new RoutedCommand("ToggleOverstrike", typeof(TextEditor));
+
+		/// <summary>
 		/// Deletes the current line.
 		/// The default shortcut is Ctrl+D.
 		/// </summary>

--- a/ICSharpCode.AvalonEdit/Editing/EditingCommandHandler.cs
+++ b/ICSharpCode.AvalonEdit/Editing/EditingCommandHandler.cs
@@ -72,12 +72,18 @@ namespace ICSharpCode.AvalonEdit.Editing
 			AddBinding(EditingCommands.EnterParagraphBreak, ModifierKeys.None, Key.Enter, OnEnter);
 			AddBinding(EditingCommands.EnterLineBreak, ModifierKeys.Shift, Key.Enter, OnEnter);
 			AddBinding(EditingCommands.TabForward, ModifierKeys.None, Key.Tab, OnTab);
-			AddBinding(EditingCommands.TabBackward, ModifierKeys.Shift, Key.Tab, OnShiftTab);
-			
+			AddBinding(EditingCommands.TabBackward, ModifierKeys.Shift, Key.Tab, OnShiftTab);			                  
+
+			AddBinding(AvalonEditCommands.ToggleOverstrike, ModifierKeys.None, Key.Insert, OnInsert(CaretMovementType.None));
+
 			CommandBindings.Add(new CommandBinding(ApplicationCommands.Copy, OnCopy, CanCutOrCopy));
 			CommandBindings.Add(new CommandBinding(ApplicationCommands.Cut, OnCut, CanCutOrCopy));
 			CommandBindings.Add(new CommandBinding(ApplicationCommands.Paste, OnPaste, CanPaste));
 			
+			AddBinding(ApplicationCommands.Copy,  ModifierKeys.Control, Key.Insert, OnCopy);
+			AddBinding(ApplicationCommands.Cut,   ModifierKeys.Shift,   Key.Delete, OnCut);
+			AddBinding(ApplicationCommands.Paste, ModifierKeys.Shift,   Key.Insert, OnPaste);
+
 			CommandBindings.Add(new CommandBinding(AvalonEditCommands.DeleteLine, OnDeleteLine));
 			
 			CommandBindings.Add(new CommandBinding(AvalonEditCommands.RemoveLeadingWhitespace, OnRemoveLeadingWhitespace));
@@ -238,6 +244,17 @@ namespace ICSharpCode.AvalonEdit.Editing
 						}
 					}
 				}, target, args, DefaultSegmentType.CurrentLine);
+		}
+		#endregion
+		
+		#region Insert
+		static ExecutedRoutedEventHandler OnInsert(CaretMovementType caretMovement)
+		{
+			return (target, args) => {            
+				TextArea textArea = GetTextArea(target);
+				if(textArea.Options.AllowToggleOverstrikeMode) 
+					textArea.OverstrikeMode = !textArea.OverstrikeMode;
+			};
 		}
 		#endregion
 		

--- a/ICSharpCode.AvalonEdit/Editing/EditingCommandHandler.cs
+++ b/ICSharpCode.AvalonEdit/Editing/EditingCommandHandler.cs
@@ -72,18 +72,18 @@ namespace ICSharpCode.AvalonEdit.Editing
 			AddBinding(EditingCommands.EnterParagraphBreak, ModifierKeys.None, Key.Enter, OnEnter);
 			AddBinding(EditingCommands.EnterLineBreak, ModifierKeys.Shift, Key.Enter, OnEnter);
 			AddBinding(EditingCommands.TabForward, ModifierKeys.None, Key.Tab, OnTab);
-			AddBinding(EditingCommands.TabBackward, ModifierKeys.Shift, Key.Tab, OnShiftTab);			                  
-
-			AddBinding(AvalonEditCommands.ToggleOverstrike, ModifierKeys.None, Key.Insert, OnInsert(CaretMovementType.None));
+			AddBinding(EditingCommands.TabBackward, ModifierKeys.Shift, Key.Tab, OnShiftTab);			                  			
 
 			CommandBindings.Add(new CommandBinding(ApplicationCommands.Copy, OnCopy, CanCutOrCopy));
 			CommandBindings.Add(new CommandBinding(ApplicationCommands.Cut, OnCut, CanCutOrCopy));
 			CommandBindings.Add(new CommandBinding(ApplicationCommands.Paste, OnPaste, CanPaste));
-			
-			AddBinding(ApplicationCommands.Copy,  ModifierKeys.Control, Key.Insert, OnCopy);
-			AddBinding(ApplicationCommands.Cut,   ModifierKeys.Shift,   Key.Delete, OnCut);
-			AddBinding(ApplicationCommands.Paste, ModifierKeys.Shift,   Key.Insert, OnPaste);
 
+			InputBindings.Add(TextAreaDefaultInputHandler.CreateFrozenKeyBinding(ApplicationCommands.Copy, ModifierKeys.Control, Key.Insert ));
+			InputBindings.Add(TextAreaDefaultInputHandler.CreateFrozenKeyBinding(ApplicationCommands.Cut, ModifierKeys.Shift, Key.Delete ));
+			InputBindings.Add(TextAreaDefaultInputHandler.CreateFrozenKeyBinding(ApplicationCommands.Paste, ModifierKeys.Shift, Key.Insert ));
+			
+			AddBinding(AvalonEditCommands.ToggleOverstrike, ModifierKeys.None, Key.Insert, ToggleOverstrike);			
+			
 			CommandBindings.Add(new CommandBinding(AvalonEditCommands.DeleteLine, OnDeleteLine));
 			
 			CommandBindings.Add(new CommandBinding(AvalonEditCommands.RemoveLeadingWhitespace, OnRemoveLeadingWhitespace));
@@ -247,14 +247,12 @@ namespace ICSharpCode.AvalonEdit.Editing
 		}
 		#endregion
 		
-		#region Insert
-		static ExecutedRoutedEventHandler OnInsert(CaretMovementType caretMovement)
-		{
-			return (target, args) => {            
-				TextArea textArea = GetTextArea(target);
-				if(textArea.Options.AllowToggleOverstrikeMode) 
-					textArea.OverstrikeMode = !textArea.OverstrikeMode;
-			};
+		#region Toggle Overstrike
+		static void ToggleOverstrike(object target, ExecutedRoutedEventArgs args)
+		{			
+			TextArea textArea = GetTextArea(target);
+			if(textArea.Options.AllowToggleOverstrikeMode) 
+				textArea.OverstrikeMode = !textArea.OverstrikeMode;
 		}
 		#endregion
 		

--- a/ICSharpCode.AvalonEdit/Editing/TextArea.cs
+++ b/ICSharpCode.AvalonEdit/Editing/TextArea.cs
@@ -970,13 +970,7 @@ namespace ICSharpCode.AvalonEdit.Editing
 		/// <inheritdoc/>
 		protected override void OnPreviewKeyDown(KeyEventArgs e)
 		{
-			base.OnPreviewKeyDown(e);
-			
-			if (!e.Handled && e.Key == Key.Insert && this.Options.AllowToggleOverstrikeMode) {
-				this.OverstrikeMode = !this.OverstrikeMode;
-				e.Handled = true;
-				return;
-			}
+			base.OnPreviewKeyDown(e);			
 			
 			foreach (TextAreaStackedInputHandler h in stackedInputHandlers) {
 				if (e.Handled)


### PR DESCRIPTION
This pull request adds support for the following shortcuts that are missing ( #43 ):
* `CTRL`+`INS` (copy)
* `SHIFT`+`DEL` (cut)
* `SHIFT`+`INS` (paste)

Note: since the `Insert` key was intercepted early for toggling Overstrike mode, I had to move it from `OnPreviewKeyDown()` and make it work as a normal editing command.  