### PR TITLE
Added TextEditor.Delete()

### DIFF
--- a/ICSharpCode.AvalonEdit/TextEditor.cs
+++ b/ICSharpCode.AvalonEdit/TextEditor.cs
@@ -580,6 +580,14 @@ namespace ICSharpCode.AvalonEdit
 		}
 		
 		/// <summary>
+		/// Removes the current selection without copying it to the clipboard.
+		/// </summary>
+		public void Delete()
+		{
+			Execute(ApplicationCommands.Delete);		
+		}
+
+		/// <summary>
 		/// Ends the current group of document changes.
 		/// </summary>
 		public void EndChange()


### PR DESCRIPTION
Just a small thing... `TextEditor` has `Copy()`, `Cut()`, `Paste()` methods but not `Delete()` (which clears the selection without copying to the clipboard). 

I have a non WPF based app (that featured the old WinForm editor), with a context menu that has the "delete" item, and the only way to connect it is to have this ugly:

```C#
editor.SelectedText = ""; 
```
