### PR TITLE
Fix #51 DefaultIndentationStrategy fails with spaces right of the caret

### DIFF
--- a/ICSharpCode.AvalonEdit/Indentation/DefaultIndentationStrategy.cs
+++ b/ICSharpCode.AvalonEdit/Indentation/DefaultIndentationStrategy.cs
@@ -39,8 +39,8 @@ namespace ICSharpCode.AvalonEdit.Indentation
 			if (previousLine != null) {
 				ISegment indentationSegment = TextUtilities.GetWhitespaceAfter(document, previousLine.Offset);
 				string indentation = document.GetText(indentationSegment);
-				// copy indentation to line
-				indentationSegment = TextUtilities.GetWhitespaceAfter(document, line.Offset);
+				// copy indentation to line				
+				indentationSegment = new SimpleSegment(line.Offset,0);
 				document.Replace(indentationSegment, indentation);
 			}
 		}


### PR DESCRIPTION
Fixed by not scanning for leading spaces on the new line, which should be rather good for a default strategy.