### PR TITLE
Introduced a way for extending LineNumberMargin.

### DIFF
--- a/ICSharpCode.AvalonEdit/Editing/LineNumberMargin.cs
+++ b/ICSharpCode.AvalonEdit/Editing/LineNumberMargin.cs
@@ -80,10 +80,10 @@ namespace ICSharpCode.AvalonEdit.Editing
 			if (textView != null && textView.VisualLinesValid) {
 				var foreground = (Brush)GetValue(Control.ForegroundProperty);
 				foreach (VisualLine line in textView.VisualLines) {
-					int lineNumber = line.FirstDocumentLine.LineNumber;
+					string lineNumber = GetLineNumberString(line);
 					FormattedText text = TextFormatterFactory.CreateFormattedText(
 						this,
-						lineNumber.ToString(CultureInfo.CurrentCulture),
+						lineNumber,
 						typeface, emSize, foreground
 					);
 					double y = line.GetTextLineVisualYPosition(line.TextLines[0], VisualYPosition.TextTop);
@@ -91,7 +91,12 @@ namespace ICSharpCode.AvalonEdit.Editing
 				}
 			}
 		}
-		
+
+		protected virtual string GetLineNumberString(VisualLine line)
+		{
+			return line.FirstDocumentLine.LineNumber.ToString(CultureInfo.CurrentCulture);
+		}
+
 		/// <inheritdoc/>
 		protected override void OnTextViewChanged(TextView oldTextView, TextView newTextView)
 		{

--- a/ICSharpCode.AvalonEdit/TextEditor.cs
+++ b/ICSharpCode.AvalonEdit/TextEditor.cs
@@ -488,7 +488,7 @@ namespace ICSharpCode.AvalonEdit
 			TextEditor editor = (TextEditor)d;
 			var leftMargins = editor.TextArea.LeftMargins;
 			if ((bool)e.NewValue) {
-				LineNumberMargin lineNumbers = new LineNumberMargin();
+				LineNumberMargin lineNumbers = ((TextEditor)d).GetLineNumberMargin();
 				Line line = (Line)DottedLineMargin.Create();
 				leftMargins.Insert(0, lineNumbers);
 				leftMargins.Insert(1, line);
@@ -506,6 +506,11 @@ namespace ICSharpCode.AvalonEdit
 					}
 				}
 			}
+		}
+
+		protected virtual LineNumberMargin GetLineNumberMargin()
+		{
+			return new LineNumberMargin();
 		}
 		#endregion
 		


### PR DESCRIPTION
This is useful in the process of making a diff tool using AvalonEdit. E.g. some of the lines should't have a number and empty string can be returned by the GetLineNumberString method for this lines.