### PR TITLE
Added syntax highlighting options for styling font-family and font-size

### DIFF
--- a/ICSharpCode.AvalonEdit.Sample/CustomHighlighting.xshd
+++ b/ICSharpCode.AvalonEdit.Sample/CustomHighlighting.xshd
@@ -23,12 +23,12 @@
 			<!-- ... -->
 		</Keywords>
 		
-		<Keywords fontWeight="bold" fontStyle="italic" foreground="Red">
+		<Keywords fontFamily="Comic Sans MS, cursive, sans-serif" fontSize="16" fontWeight="bold" fontStyle="italic" foreground="Red">
 			<Word>AvalonEdit</Word>
 		</Keywords>
 		
 		<!-- Digits -->
-		<Rule foreground="DarkBlue">
+		<Rule foreground="DarkBlue" fontSize="8">
             \b0[xX][0-9a-fA-F]+  # hex number
         |    \b
             (    \d+(\.[0-9]+)?   #number with optional floating point

--- a/ICSharpCode.AvalonEdit/Highlighting/HighlightingColor.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/HighlightingColor.cs
@@ -222,7 +222,7 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 			info.AddValue("Background", this.Background);
             info.AddValue("HasFamily", this.FontFamily != null);
             if (this.FontFamily != null)
-                info.AddValue("Family", this.FontFamily.FamilyNames.FirstOrDefault());
+                info.AddValue("Family", this.FontFamily.Source);
             info.AddValue("HasSize", this.FontSize.HasValue);
             if (this.FontSize.HasValue)
                 info.AddValue("Size", this.FontSize.Value.ToString());
@@ -257,6 +257,18 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 				b.Append(Underline.Value ? "underline" : "none");
 				b.Append("; ");
 			}
+            if (FontFamily != null)
+            {
+                b.Append("font-family: ");
+                b.Append(FontFamily.Source);
+                b.Append("; ");
+            }
+            if (FontSize != null)
+            {
+                b.Append("font-size: ");
+                b.Append(FontSize.Value.ToString());
+                b.Append("px; ");
+            }
 			return b.ToString();
 		}
 		

--- a/ICSharpCode.AvalonEdit/Highlighting/HighlightingColor.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/HighlightingColor.cs
@@ -37,45 +37,14 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 		internal static readonly HighlightingColor Empty = FreezableHelper.FreezeAndReturn(new HighlightingColor());
 		
 		string name;
-        FontFamily fontFamily = null;
-        int? fontSize;
         FontWeight? fontWeight;
 		FontStyle? fontStyle;
 		bool? underline;
 		HighlightingBrush foreground;
 		HighlightingBrush background;
-		bool frozen;
-		
-		/// <summary>
-		/// Gets/Sets the name of the color.
-		/// </summary>
-		public string Name {
-			get {
-				return name;
-			}
-			set {
-				if (frozen)
-					throw new InvalidOperationException();
-				name = value;
-			}
-		}
-
-        /// <summary>
-        /// Gets/sets the font family. Null if the highlighting color does not change the font style.
-        /// </summary>
-        public FontFamily FontFamily
-        {
-            get
-            {
-                return fontFamily;
-            }
-            set
-            {
-                if (frozen)
-                    throw new InvalidOperationException();
-                fontFamily = value;
-            }
-        }
+        FontFamily fontFamily = null;
+        int? fontSize;
+        bool frozen;
 
         /// <summary>
         /// Gets/sets the font size. Null if the highlighting color does not change the font style.
@@ -163,11 +132,45 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 				background = value;
 			}
 		}
-		
-		/// <summary>
-		/// Creates a new HighlightingColor instance.
-		/// </summary>
-		public HighlightingColor()
+
+        /// <summary>
+        /// Gets/Sets the name of the color.
+        /// </summary>
+        public string Name
+        {
+            get
+            {
+                return name;
+            }
+            set
+            {
+                if (frozen)
+                    throw new InvalidOperationException();
+                name = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets/sets the font family. Null if the highlighting color does not change the font style.
+        /// </summary>
+        public FontFamily FontFamily
+        {
+            get
+            {
+                return fontFamily;
+            }
+            set
+            {
+                if (frozen)
+                    throw new InvalidOperationException();
+                fontFamily = value;
+            }
+        }
+
+        /// <summary>
+        /// Creates a new HighlightingColor instance.
+        /// </summary>
+        public HighlightingColor()
 		{
 		}
 		

--- a/ICSharpCode.AvalonEdit/Highlighting/HighlightingColorizer.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/HighlightingColorizer.cs
@@ -256,10 +256,10 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 				if (b != null)
 					element.BackgroundBrush = b;
 			}
-			if (color.FontStyle != null || color.FontWeight != null) {
+			if (color.FontStyle != null || color.FontWeight != null || color.FontFamily != null) {
 				Typeface tf = element.TextRunProperties.Typeface;
-				element.TextRunProperties.SetTypeface(new Typeface(
-					tf.FontFamily,
+				 element.TextRunProperties.SetTypeface(new Typeface(
+                    color.FontFamily ?? tf.FontFamily,
 					color.FontStyle ?? tf.Style,
 					color.FontWeight ?? tf.Weight,
 					tf.Stretch
@@ -267,6 +267,8 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 			}
 			if(color.Underline ?? false)
 				element.TextRunProperties.SetTextDecorations(TextDecorations.Underline);
+            if (color.FontSize.HasValue)
+                element.TextRunProperties.SetFontRenderingEmSize(color.FontSize.Value);
 		}
 		
 		/// <summary>

--- a/ICSharpCode.AvalonEdit/Highlighting/Resources/CSharp-Mode.xshd
+++ b/ICSharpCode.AvalonEdit/Highlighting/Resources/CSharp-Mode.xshd
@@ -26,7 +26,7 @@
 	<Color name="GetSetAddRemove" foreground="SaddleBrown" exampleText="int Prop { get; set; }"/>
 	<Color name="TrueFalse" fontWeight="bold" foreground="DarkCyan" exampleText="b = false; a = true;" />
 	<Color name="TypeKeywords" fontWeight="bold" foreground="DarkCyan" exampleText="if (x is int) { a = x as int; type = typeof(int); size = sizeof(int); c = new object(); }"/>
-	
+    
 	<Property name="DocCommentMarker" value="///" />
 	
 	<RuleSet name="CommentMarkerSet">

--- a/ICSharpCode.AvalonEdit/Highlighting/Resources/MarkDown-Mode.xshd
+++ b/ICSharpCode.AvalonEdit/Highlighting/Resources/MarkDown-Mode.xshd
@@ -1,37 +1,37 @@
 ﻿<?xml version="1.0"?>
 <SyntaxDefinition name="MarkDown" extensions=".md" xmlns="http://icsharpcode.net/sharpdevelop/syntaxdefinition/2008">
-  <Color name="Heading1" fontFamily="Impact, Charcoal, sans-serif" foreground="Maroon" fontSize="36" exampleText="# Title #" />
-  <Color name="Heading2" fontFamily="Comic Sans MS, cursive, sans-serif" foreground="Maroon" fontSize="28" exampleText="# Title #" />
-  <Color name="Heading3" fontFamily="Arial Black, Gadget, sans-serif" foreground="Maroon" fontSize="24" exampleText="# Title #" />
-  <Color name="Heading4" fontFamily="Arial, Helvetica, sans-serif" foreground="Maroon" fontSize="20" exampleText="# Title #" />
-  <Color name="Heading5" fontFamily="Trebuchet MS, Helvetica, sans-serif" foreground="Maroon" fontSize="16" exampleText="# Title #" />
-  <Color name="Heading6" fontFamily="Verdana, Geneva, sans-serif" foreground="Maroon" fontSize="12" exampleText="# Title #" />
-  <Color name="Emphasis" fontStyle="italic" exampleText="*this* is important!" />
+    <Color name="Heading1" fontFamily="Impact, Charcoal, sans-serif" foreground="Maroon" fontSize="36" exampleText="# Title #" />
+    <Color name="Heading2" fontFamily="Tahoma, Geneva, sans-serif" foreground="Maroon" fontSize="28" exampleText="# Title #" />
+    <Color name="Heading3" fontFamily="Arial Black, Gadget, sans-serif" foreground="Maroon" fontSize="24" exampleText="# Title #" />
+    <Color name="Heading4" fontFamily="Arial, Helvetica, sans-serif" foreground="Maroon" fontSize="20" exampleText="# Title #" />
+    <Color name="Heading5" fontFamily="Trebuchet MS, Helvetica, sans-serif" foreground="Maroon" fontSize="16" exampleText="# Title #" />
+    <Color name="Heading6" fontFamily="Verdana, Geneva, sans-serif" foreground="Maroon" fontSize="12" exampleText="# Title #" />
+    <Color name="Emphasis" fontStyle="italic" exampleText="*this* is important!" />
 	<Color name="StrongEmphasis" fontWeight="bold" exampleText="**this** is more important!" />
 	<Color name="Code" exampleText="this is `int.GetHashCode()`" />
-	<Color name="BlockQuote" foreground="DarkBlue" exampleText="&gt; This is a\r\n&gt; quote." />
+	<Color name="BlockQuote" fontSize="18" fontFamily="Palatino Linotype, Book Antiqua, Palatino, serif" foreground="DarkBlue" exampleText="&gt; This is a\r\n&gt; quote." />
 	<Color name="Link" foreground="Blue" exampleText="[text](http://example.com)" />
 	<Color name="Image" foreground="Green" exampleText="[text][http://example.com/test.png]" />
 	<Color name="LineBreak" background="LightGray" exampleText="end of line      \r\n2nd line   " />
 	
 	<RuleSet ignoreCase="true">
         <Rule color="Heading1">
-            ^[#]{1}[ ]{1}.*
+            ^(\#){1}\s.*
         </Rule>
         <Rule color="Heading2">
-            ^[#]{2}[ ]{1}.*
+            ^(\#){2}\s.*
         </Rule>
         <Rule color="Heading3">
-            ^[#]{3}[ ]{1}.*
+            ^(\#){3}\s.*
         </Rule>
         <Rule color="Heading4">
-            ^[#]{4}[ ]{1}.*
+            ^(\#){4}\s.*
         </Rule>
         <Rule color="Heading5">
-            ^[#]{5}[ ]{1}.*
+            ^(\#){5}\s.*
         </Rule>
         <Rule color="Heading6">
-            ^[#]{6}[ ]{1}.*
+            ^(\#){6}\s.*
         </Rule>
         <Rule color="StrongEmphasis">
 			\*\*.*\*\*
@@ -48,7 +48,7 @@
 		<Rule color="Code">
 			`.*`
 		</Rule>
-		<Span color="Code" ruleSet="C#/" multiline="true">
+        <Span color="Code" ruleSet="C#/" multiline="true">
 			<Begin>^\t</Begin>
 			<End>^(?!\t)</End>
 		</Span>
@@ -56,7 +56,63 @@
 			<Begin>^[ ]{4}</Begin>
 			<End>^(?![ ]{4})</End>
 		</Span>
-		<Span color="BlockQuote" multiline="true">
+        <Span color="Code" ruleSet="C#/" multiline="true">
+            <Begin>```(csharp|c\#)</Begin>
+            <End>```</End>
+        </Span>
+        <Span color="Code" ruleSet="Boo/" multiline="true">
+            <Begin>```boo</Begin>
+            <End>```</End>
+        </Span>
+        <Span color="Code" ruleSet="C++/" multiline="true">
+            <Begin>```(cpp|c\+\+)</Begin>
+            <End>```</End>
+        </Span>
+        <Span color="Code" ruleSet="CSS/" multiline="true">
+            <Begin>```css</Begin>
+            <End>```</End>
+        </Span>
+        <Span color="Code" ruleSet="HTML/" multiline="true">
+            <Begin>```html</Begin>
+            <End>```</End>
+        </Span>
+        <Span color="Code" ruleSet="Java/" multiline="true">
+            <Begin>```java</Begin>
+            <End>```</End>
+        </Span>
+        <Span color="Code" ruleSet="JavaScript/" multiline="true">
+            <Begin>```(javascript|jscript)</Begin>
+            <End>```</End>
+        </Span>
+        <Span color="Code" ruleSet="Patch/" multiline="true">
+            <Begin>```patch</Begin>
+            <End>```</End>
+        </Span>
+        <Span color="Code" ruleSet="PHP/" multiline="true">
+            <Begin>```php</Begin>
+            <End>```</End>
+        </Span>
+        <Span color="Code" ruleSet="PowerShell/" multiline="true">
+            <Begin>```powershell</Begin>
+            <End>```</End>
+        </Span>
+        <Span color="Code" ruleSet="TeX/" multiline="true">
+            <Begin>```tex</Begin>
+            <End>```</End>
+        </Span>
+        <Span color="Code" ruleSet="VB/" multiline="true">
+            <Begin>```(vb|visualbasic)</Begin>
+            <End>```</End>
+        </Span>
+        <Span color="Code" ruleSet="XML/" multiline="true">
+            <Begin>```xml</Begin>
+            <End>```</End>
+        </Span>
+        <Span color="Code" ruleSet="XmlDoc/" multiline="true">
+            <Begin>```xmldoc</Begin>
+            <End>```</End>
+        </Span>
+        <Span color="BlockQuote" multiline="true">
 			<Begin>^&gt;</Begin>
 			<End>^(?!&gt;)</End>
 		</Span>

--- a/ICSharpCode.AvalonEdit/Highlighting/Resources/MarkDown-Mode.xshd
+++ b/ICSharpCode.AvalonEdit/Highlighting/Resources/MarkDown-Mode.xshd
@@ -1,39 +1,40 @@
 ﻿<?xml version="1.0"?>
 <SyntaxDefinition name="MarkDown" extensions=".md" xmlns="http://icsharpcode.net/sharpdevelop/syntaxdefinition/2008">
-    <Color name="Heading1" fontFamily="Impact, Charcoal, sans-serif" foreground="Maroon" fontSize="36" exampleText="# Title #" />
-    <Color name="Heading2" fontFamily="Tahoma, Geneva, sans-serif" foreground="Maroon" fontSize="28" exampleText="# Title #" />
-    <Color name="Heading3" fontFamily="Arial Black, Gadget, sans-serif" foreground="Maroon" fontSize="24" exampleText="# Title #" />
-    <Color name="Heading4" fontFamily="Arial, Helvetica, sans-serif" foreground="Maroon" fontSize="20" exampleText="# Title #" />
-    <Color name="Heading5" fontFamily="Trebuchet MS, Helvetica, sans-serif" foreground="Maroon" fontSize="16" exampleText="# Title #" />
-    <Color name="Heading6" fontFamily="Verdana, Geneva, sans-serif" foreground="Maroon" fontSize="12" exampleText="# Title #" />
-    <Color name="Emphasis" fontStyle="italic" exampleText="*this* is important!" />
+  <Color name="Heading1" fontFamily="Tahoma, Geneva, sans-serif" foreground="Maroon" fontSize="36" exampleText="# Title #" />
+  <Color name="Heading2" fontFamily="Tahoma, Geneva, sans-serif" foreground="Maroon" fontSize="28" exampleText="# Title #" />
+  <Color name="Heading3" fontFamily="Arial, Helvetica, sans-serif" foreground="Maroon" fontSize="24" exampleText="# Title #" />
+  <Color name="Heading4" fontFamily="Arial, Helvetica, sans-serif" foreground="Maroon" fontSize="20" exampleText="# Title #" />
+  <Color name="Heading5" fontFamily="Trebuchet MS, Helvetica, sans-serif" foreground="Maroon" fontSize="16" exampleText="# Title #" />
+  <Color name="Heading6" fontFamily="Trebuchet MS, Helvetica, sans-serif" foreground="Maroon" fontSize="12" exampleText="# Title #" />
+  <Color name="Emphasis" fontStyle="italic" exampleText="*this* is important!" />
 	<Color name="StrongEmphasis" fontWeight="bold" exampleText="**this** is more important!" />
 	<Color name="Code" exampleText="this is `int.GetHashCode()`" />
 	<Color name="BlockQuote" fontSize="18" fontFamily="Palatino Linotype, Book Antiqua, Palatino, serif" foreground="DarkBlue" exampleText="&gt; This is a\r\n&gt; quote." />
 	<Color name="Link" foreground="Blue" exampleText="[text](http://example.com)" />
 	<Color name="Image" foreground="Green" exampleText="[text][http://example.com/test.png]" />
 	<Color name="LineBreak" background="LightGray" exampleText="end of line      \r\n2nd line   " />
-	
-	<RuleSet ignoreCase="true">
-        <Rule color="Heading1">
-            ^(\#){1}\s.*
-        </Rule>
-        <Rule color="Heading2">
-            ^(\#){2}\s.*
-        </Rule>
-        <Rule color="Heading3">
-            ^(\#){3}\s.*
-        </Rule>
-        <Rule color="Heading4">
-            ^(\#){4}\s.*
-        </Rule>
-        <Rule color="Heading5">
-            ^(\#){5}\s.*
-        </Rule>
-        <Rule color="Heading6">
-            ^(\#){6}\s.*
-        </Rule>
-        <Rule color="StrongEmphasis">
+  <Color name="default" fontFamily="Verdana, Geneva, sans-serif" fontSize="24"/>
+
+  <RuleSet ignoreCase="true">
+    <Rule color="Heading1">
+        ^(\#){1}\s.*
+    </Rule>
+    <Rule color="Heading2">
+        ^(\#){2}\s.*
+    </Rule>
+    <Rule color="Heading3">
+        ^(\#){3}\s.*
+    </Rule>
+    <Rule color="Heading4">
+        ^(\#){4}\s.*
+    </Rule>
+    <Rule color="Heading5">
+        ^(\#){5}\s.*
+    </Rule>
+    <Rule color="Heading6">
+        ^(\#){6}\s.*
+    </Rule>
+    <Rule color="StrongEmphasis">
 			\*\*.*\*\*
 		</Rule>
 		<Rule color="StrongEmphasis">
@@ -48,7 +49,7 @@
 		<Rule color="Code">
 			`.*`
 		</Rule>
-        <Span color="Code" ruleSet="C#/" multiline="true">
+    <Span color="Code" ruleSet="C#/" multiline="true">
 			<Begin>^\t</Begin>
 			<End>^(?!\t)</End>
 		</Span>
@@ -56,63 +57,63 @@
 			<Begin>^[ ]{4}</Begin>
 			<End>^(?![ ]{4})</End>
 		</Span>
-        <Span color="Code" ruleSet="C#/" multiline="true">
-            <Begin>```(csharp|c\#)</Begin>
-            <End>```</End>
-        </Span>
-        <Span color="Code" ruleSet="Boo/" multiline="true">
-            <Begin>```boo</Begin>
-            <End>```</End>
-        </Span>
-        <Span color="Code" ruleSet="C++/" multiline="true">
-            <Begin>```(cpp|c\+\+)</Begin>
-            <End>```</End>
-        </Span>
-        <Span color="Code" ruleSet="CSS/" multiline="true">
-            <Begin>```css</Begin>
-            <End>```</End>
-        </Span>
-        <Span color="Code" ruleSet="HTML/" multiline="true">
-            <Begin>```html</Begin>
-            <End>```</End>
-        </Span>
-        <Span color="Code" ruleSet="Java/" multiline="true">
-            <Begin>```java</Begin>
-            <End>```</End>
-        </Span>
-        <Span color="Code" ruleSet="JavaScript/" multiline="true">
-            <Begin>```(javascript|jscript)</Begin>
-            <End>```</End>
-        </Span>
-        <Span color="Code" ruleSet="Patch/" multiline="true">
-            <Begin>```patch</Begin>
-            <End>```</End>
-        </Span>
-        <Span color="Code" ruleSet="PHP/" multiline="true">
-            <Begin>```php</Begin>
-            <End>```</End>
-        </Span>
-        <Span color="Code" ruleSet="PowerShell/" multiline="true">
-            <Begin>```powershell</Begin>
-            <End>```</End>
-        </Span>
-        <Span color="Code" ruleSet="TeX/" multiline="true">
-            <Begin>```tex</Begin>
-            <End>```</End>
-        </Span>
-        <Span color="Code" ruleSet="VB/" multiline="true">
-            <Begin>```(vb|visualbasic)</Begin>
-            <End>```</End>
-        </Span>
-        <Span color="Code" ruleSet="XML/" multiline="true">
-            <Begin>```xml</Begin>
-            <End>```</End>
-        </Span>
-        <Span color="Code" ruleSet="XmlDoc/" multiline="true">
-            <Begin>```xmldoc</Begin>
-            <End>```</End>
-        </Span>
-        <Span color="BlockQuote" multiline="true">
+    <Span color="Code" ruleSet="C#/" multiline="true">
+      <Begin>```(csharp|c\#)</Begin>
+      <End>```</End>
+    </Span>
+    <Span color="Code" ruleSet="Boo/" multiline="true">
+      <Begin>```boo</Begin>
+      <End>```</End>
+    </Span>
+    <Span color="Code" ruleSet="C++/" multiline="true">
+      <Begin>```(cpp|c\+\+)</Begin>
+      <End>```</End>
+    </Span>
+    <Span color="Code" ruleSet="CSS/" multiline="true">
+      <Begin>```css</Begin>
+      <End>```</End>
+    </Span>
+    <Span color="Code" ruleSet="HTML/" multiline="true">
+      <Begin>```html</Begin>
+      <End>```</End>
+    </Span>
+    <Span color="Code" ruleSet="Java/" multiline="true">
+      <Begin>```java</Begin>
+      <End>```</End>
+    </Span>
+    <Span color="Code" ruleSet="JavaScript/" multiline="true">
+      <Begin>```(javascript|jscript)</Begin>
+      <End>```</End>
+    </Span>
+    <Span color="Code" ruleSet="Patch/" multiline="true">
+      <Begin>```patch</Begin>
+      <End>```</End>
+    </Span>
+    <Span color="Code" ruleSet="PHP/" multiline="true">
+      <Begin>```php</Begin>
+      <End>```</End>
+    </Span>
+    <Span color="Code" ruleSet="PowerShell/" multiline="true">
+      <Begin>```powershell</Begin>
+      <End>```</End>
+    </Span>
+    <Span color="Code" ruleSet="TeX/" multiline="true">
+      <Begin>```tex</Begin>
+      <End>```</End>
+    </Span>
+    <Span color="Code" ruleSet="VB/" multiline="true">
+      <Begin>```(vb|visualbasic)</Begin>
+      <End>```</End>
+    </Span>
+    <Span color="Code" ruleSet="XML/" multiline="true">
+      <Begin>```xml</Begin>
+      <End>```</End>
+    </Span>
+    <Span color="Code" ruleSet="XmlDoc/" multiline="true">
+      <Begin>```xmldoc</Begin>
+      <End>```</End>
+    </Span>
+    <Span color="BlockQuote" multiline="true">
 			<Begin>^&gt;</Begin>
 			<End>^(?!&gt;)</End>
 		</Span>

--- a/ICSharpCode.AvalonEdit/Highlighting/Resources/MarkDown-Mode.xshd
+++ b/ICSharpCode.AvalonEdit/Highlighting/Resources/MarkDown-Mode.xshd
@@ -1,19 +1,39 @@
 ﻿<?xml version="1.0"?>
 <SyntaxDefinition name="MarkDown" extensions=".md" xmlns="http://icsharpcode.net/sharpdevelop/syntaxdefinition/2008">
-	<Color name="Heading" foreground="Maroon" exampleText="# Title #" />
-	<Color name="Emphasis" fontStyle="italic" exampleText="*this* is important!" />
+    <Color name="Heading1" foreground="Maroon" fontSize="30" exampleText="# Title #" />
+    <Color name="Heading2" foreground="Maroon" fontSize="27" exampleText="# Title #" />
+    <Color name="Heading3" foreground="Maroon" fontSize="24" exampleText="# Title #" />
+    <Color name="Heading4" foreground="Maroon" fontSize="21" exampleText="# Title #" />
+    <Color name="Heading5" foreground="Maroon" fontSize="18" exampleText="# Title #" />
+    <Color name="Heading6" foreground="Maroon" fontSize="15" exampleText="# Title #" />
+    <Color name="Emphasis" fontStyle="italic" exampleText="*this* is important!" />
 	<Color name="StrongEmphasis" fontWeight="bold" exampleText="**this** is more important!" />
-	<Color name="Code" exampleText="this is `int.GetHashCode()`" />
+	<Color name="Code" fontFamily="Footlight MT Light" exampleText="this is `int.GetHashCode()`" />
 	<Color name="BlockQuote" foreground="DarkBlue" exampleText="&gt; This is a\r\n&gt; quote." />
 	<Color name="Link" foreground="Blue" exampleText="[text](http://example.com)" />
 	<Color name="Image" foreground="Green" exampleText="[text][http://example.com/test.png]" />
 	<Color name="LineBreak" background="LightGray" exampleText="end of line      \r\n2nd line   " />
 	
 	<RuleSet ignoreCase="true">
-		<Rule color="Heading">
-			^\#.*
-		</Rule>
-		<Rule color="StrongEmphasis">
+        <Rule color="Heading1">
+            ^[#]{1}[ ]{1}.*
+        </Rule>
+        <Rule color="Heading2">
+            ^[#]{2}[ ]{1}.*
+        </Rule>
+        <Rule color="Heading3">
+            ^[#]{3}[ ]{1}.*
+        </Rule>
+        <Rule color="Heading4">
+            ^[#]{4}[ ]{1}.*
+        </Rule>
+        <Rule color="Heading5">
+            ^[#]{5}[ ]{1}.*
+        </Rule>
+        <Rule color="Heading6">
+            ^[#]{6}[ ]{1}.*
+        </Rule>
+        <Rule color="StrongEmphasis">
 			\*\*.*\*\*
 		</Rule>
 		<Rule color="StrongEmphasis">

--- a/ICSharpCode.AvalonEdit/Highlighting/Resources/MarkDown-Mode.xshd
+++ b/ICSharpCode.AvalonEdit/Highlighting/Resources/MarkDown-Mode.xshd
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0"?>
 <SyntaxDefinition name="MarkDown" extensions=".md" xmlns="http://icsharpcode.net/sharpdevelop/syntaxdefinition/2008">
-    <Color name="Heading1" foreground="Maroon" fontSize="30" exampleText="# Title #" />
-    <Color name="Heading2" foreground="Maroon" fontSize="27" exampleText="# Title #" />
-    <Color name="Heading3" foreground="Maroon" fontSize="24" exampleText="# Title #" />
-    <Color name="Heading4" foreground="Maroon" fontSize="21" exampleText="# Title #" />
-    <Color name="Heading5" foreground="Maroon" fontSize="18" exampleText="# Title #" />
-    <Color name="Heading6" foreground="Maroon" fontSize="15" exampleText="# Title #" />
-    <Color name="Emphasis" fontStyle="italic" exampleText="*this* is important!" />
+  <Color name="Heading1" fontFamily="Impact, Charcoal, sans-serif" foreground="Maroon" fontSize="36" exampleText="# Title #" />
+  <Color name="Heading2" fontFamily="Comic Sans MS, cursive, sans-serif" foreground="Maroon" fontSize="28" exampleText="# Title #" />
+  <Color name="Heading3" fontFamily="Arial Black, Gadget, sans-serif" foreground="Maroon" fontSize="24" exampleText="# Title #" />
+  <Color name="Heading4" fontFamily="Arial, Helvetica, sans-serif" foreground="Maroon" fontSize="20" exampleText="# Title #" />
+  <Color name="Heading5" fontFamily="Trebuchet MS, Helvetica, sans-serif" foreground="Maroon" fontSize="16" exampleText="# Title #" />
+  <Color name="Heading6" fontFamily="Verdana, Geneva, sans-serif" foreground="Maroon" fontSize="12" exampleText="# Title #" />
+  <Color name="Emphasis" fontStyle="italic" exampleText="*this* is important!" />
 	<Color name="StrongEmphasis" fontWeight="bold" exampleText="**this** is more important!" />
-	<Color name="Code" fontFamily="Footlight MT Light" exampleText="this is `int.GetHashCode()`" />
+	<Color name="Code" exampleText="this is `int.GetHashCode()`" />
 	<Color name="BlockQuote" foreground="DarkBlue" exampleText="&gt; This is a\r\n&gt; quote." />
 	<Color name="Link" foreground="Blue" exampleText="[text](http://example.com)" />
 	<Color name="Image" foreground="Green" exampleText="[text][http://example.com/test.png]" />

--- a/ICSharpCode.AvalonEdit/Highlighting/Resources/ModeV2.xsd
+++ b/ICSharpCode.AvalonEdit/Highlighting/Resources/ModeV2.xsd
@@ -19,23 +19,33 @@
 			</xsd:simpleType>
 		</xsd:union>
 	</xsd:simpleType>
-	
-	<!-- Font Style -->
-	<xsd:simpleType name="FontStyle">
-		<xsd:restriction base="xsd:string">
-			<xsd:enumeration value="italic"/>
-			<xsd:enumeration value="normal"/>
-			<xsd:enumeration value="oblique"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	
-	<!-- Color -->
+
+    <!-- Font Style -->
+    <xsd:simpleType name="FontStyle">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="italic"/>
+            <xsd:enumeration value="normal"/>
+            <xsd:enumeration value="oblique"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <!-- Font Size -->
+    <xsd:simpleType name="FontSize">
+        <xsd:restriction base="xsd:integer">
+            <xsd:minInclusive value="1"/>
+            <xsd:maxInclusive value="72"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <!-- Color -->
 	<xsd:attributeGroup name="ColorAttributes">
 		<xsd:attribute name="foreground" type="xsd:string" use="optional" />
 		<xsd:attribute name="background" type="xsd:string" use="optional" />
 		<xsd:attribute name="fontWeight" type="FontWeight" use="optional" />
-		<xsd:attribute name="fontStyle" type="FontStyle" use="optional" />
-		<xsd:attribute name="underline" type="xsd:boolean" use="optional" />
+        <xsd:attribute name="fontStyle" type="FontStyle" use="optional" />
+        <xsd:attribute name="fontFamily" type="xsd:string" use="optional" />
+        <xsd:attribute name="fontSize" type="FontSize" use="optional" />
+        <xsd:attribute name="underline" type="xsd:boolean" use="optional" />
 		<xsd:anyAttribute namespace="##other" processContents="lax" />
 	</xsd:attributeGroup>
 	

--- a/ICSharpCode.AvalonEdit/Highlighting/Resources/ModeV2.xsd
+++ b/ICSharpCode.AvalonEdit/Highlighting/Resources/ModeV2.xsd
@@ -32,18 +32,50 @@
     <!-- Font Size -->
     <xsd:simpleType name="FontSize">
         <xsd:restriction base="xsd:integer">
-            <xsd:minInclusive value="1"/>
-            <xsd:maxInclusive value="72"/>
+          <xsd:enumeration value="8"/>
+          <xsd:enumeration value="9"/>
+          <xsd:enumeration value="10"/>
+          <xsd:enumeration value="12"/>
+          <xsd:enumeration value="14"/>
+          <xsd:enumeration value="16"/>
+          <xsd:enumeration value="18"/>
+          <xsd:enumeration value="20"/>
+          <xsd:enumeration value="22"/>
+          <xsd:enumeration value="24"/>
+          <xsd:enumeration value="26"/>
+          <xsd:enumeration value="28"/>
+          <xsd:enumeration value="36"/>
+          <xsd:enumeration value="48"/>
+          <xsd:enumeration value="72"/>
         </xsd:restriction>
     </xsd:simpleType>
 
-    <!-- Color -->
+  <!-- Font Family -->
+  <xsd:simpleType name="FontFamily">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="Georgia, serif"/>
+      <xsd:enumeration value="Palatino Linotype, Book Antiqua, Palatino, serif"/>
+      <xsd:enumeration value="Times New Roman, Times, serif"/>
+      <xsd:enumeration value="Arial, Helvetica, sans-serif"/>
+      <xsd:enumeration value="Arial Black, Gadget, sans-serif"/>
+      <xsd:enumeration value="Comic Sans MS, cursive, sans-serif"/>
+      <xsd:enumeration value="Impact, Charcoal, sans-serif"/>
+      <xsd:enumeration value="Lucida Sans Unicode, Lucida Grande, sans-serif"/>
+      <xsd:enumeration value="Tahoma, Geneva, sans-serif"/>
+      <xsd:enumeration value="Trebuchet MS, Helvetica, sans-serif"/>
+      <xsd:enumeration value="Verdana, Geneva, sans-serif"/>
+      <xsd:enumeration value="Courier New, Courier, monospace"/>
+      <xsd:enumeration value="Lucida Console, Monaco, monospace"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- Color -->
 	<xsd:attributeGroup name="ColorAttributes">
 		<xsd:attribute name="foreground" type="xsd:string" use="optional" />
 		<xsd:attribute name="background" type="xsd:string" use="optional" />
 		<xsd:attribute name="fontWeight" type="FontWeight" use="optional" />
         <xsd:attribute name="fontStyle" type="FontStyle" use="optional" />
-        <xsd:attribute name="fontFamily" type="xsd:string" use="optional" />
+        <xsd:attribute name="fontFamily" type="FontFamily" use="optional" />
         <xsd:attribute name="fontSize" type="FontSize" use="optional" />
         <xsd:attribute name="underline" type="xsd:boolean" use="optional" />
 		<xsd:anyAttribute namespace="##other" processContents="lax" />

--- a/ICSharpCode.AvalonEdit/Highlighting/Resources/Resources.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/Resources/Resources.cs
@@ -35,29 +35,29 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 		
 		internal static void RegisterBuiltInHighlightings(HighlightingManager.DefaultHighlightingManager hlm)
 		{
-			hlm.RegisterHighlighting("XmlDoc", null, "XmlDoc.xshd");
-			hlm.RegisterHighlighting("C#", new[] { ".cs" }, "CSharp-Mode.xshd");
-			
-			hlm.RegisterHighlighting("JavaScript", new[] { ".js" }, "JavaScript-Mode.xshd");
-			hlm.RegisterHighlighting("HTML", new[] { ".htm", ".html" }, "HTML-Mode.xshd");
-			hlm.RegisterHighlighting("ASP/XHTML", new[] { ".asp", ".aspx", ".asax", ".asmx", ".ascx", ".master" }, "ASPX.xshd");
-			
-			hlm.RegisterHighlighting("Boo", new[] { ".boo" }, "Boo.xshd");
-			hlm.RegisterHighlighting("Coco", new[] { ".atg" }, "Coco-Mode.xshd");
-			hlm.RegisterHighlighting("CSS", new[] { ".css" }, "CSS-Mode.xshd");
-			hlm.RegisterHighlighting("C++", new[] { ".c", ".h", ".cc", ".cpp" , ".hpp" }, "CPP-Mode.xshd");
-			hlm.RegisterHighlighting("Java", new[] { ".java" }, "Java-Mode.xshd");
-			hlm.RegisterHighlighting("Patch", new[] { ".patch", ".diff" }, "Patch-Mode.xshd");
-			hlm.RegisterHighlighting("PowerShell", new[] { ".ps1", ".psm1", ".psd1" }, "PowerShell.xshd");
-			hlm.RegisterHighlighting("PHP", new[] { ".php" }, "PHP-Mode.xshd");
-			hlm.RegisterHighlighting("TeX", new[] { ".tex" }, "Tex-Mode.xshd");
-			hlm.RegisterHighlighting("VB", new[] { ".vb" }, "VB-Mode.xshd");
-			hlm.RegisterHighlighting("XML", (".xml;.xsl;.xslt;.xsd;.manifest;.config;.addin;" +
-			                                 ".xshd;.wxs;.wxi;.wxl;.proj;.csproj;.vbproj;.ilproj;" +
-			                                 ".booproj;.build;.xfrm;.targets;.xaml;.xpt;" +
-			                                 ".xft;.map;.wsdl;.disco;.ps1xml;.nuspec").Split(';'),
-			                         "XML-Mode.xshd");
-			hlm.RegisterHighlighting("MarkDown", new[] { ".md" }, "MarkDown-Mode.xshd");
+            hlm.RegisterHighlighting("XmlDoc", null, "XmlDoc.xshd");
+            hlm.RegisterHighlighting("C#", new[] { ".cs" }, "CSharp-Mode.xshd");
+
+            //hlm.RegisterHighlighting("JavaScript", new[] { ".js" }, "JavaScript-Mode.xshd");
+            //hlm.RegisterHighlighting("HTML", new[] { ".htm", ".html" }, "HTML-Mode.xshd");
+            //hlm.RegisterHighlighting("ASP/XHTML", new[] { ".asp", ".aspx", ".asax", ".asmx", ".ascx", ".master" }, "ASPX.xshd");
+
+            //hlm.RegisterHighlighting("Boo", new[] { ".boo" }, "Boo.xshd");
+            //hlm.RegisterHighlighting("Coco", new[] { ".atg" }, "Coco-Mode.xshd");
+            //hlm.RegisterHighlighting("CSS", new[] { ".css" }, "CSS-Mode.xshd");
+            //hlm.RegisterHighlighting("C++", new[] { ".c", ".h", ".cc", ".cpp", ".hpp" }, "CPP-Mode.xshd");
+            //hlm.RegisterHighlighting("Java", new[] { ".java" }, "Java-Mode.xshd");
+            //hlm.RegisterHighlighting("Patch", new[] { ".patch", ".diff" }, "Patch-Mode.xshd");
+            //hlm.RegisterHighlighting("PowerShell", new[] { ".ps1", ".psm1", ".psd1" }, "PowerShell.xshd");
+            //hlm.RegisterHighlighting("PHP", new[] { ".php" }, "PHP-Mode.xshd");
+            //hlm.RegisterHighlighting("TeX", new[] { ".tex" }, "Tex-Mode.xshd");
+            //hlm.RegisterHighlighting("VB", new[] { ".vb" }, "VB-Mode.xshd");
+            //hlm.RegisterHighlighting("XML", (".xml;.xsl;.xslt;.xsd;.manifest;.config;.addin;" +
+            //                                 ".xshd;.wxs;.wxi;.wxl;.proj;.csproj;.vbproj;.ilproj;" +
+            //                                 ".booproj;.build;.xfrm;.targets;.xaml;.xpt;" +
+            //                                 ".xft;.map;.wsdl;.disco;.ps1xml;.nuspec").Split(';'),
+            //                         "XML-Mode.xshd");
+            hlm.RegisterHighlighting("MarkDown", new[] { ".md" }, "MarkDown-Mode.xshd");
 		}
 	}
 }

--- a/ICSharpCode.AvalonEdit/Highlighting/Resources/Resources.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/Resources/Resources.cs
@@ -38,25 +38,25 @@ namespace ICSharpCode.AvalonEdit.Highlighting
             hlm.RegisterHighlighting("XmlDoc", null, "XmlDoc.xshd");
             hlm.RegisterHighlighting("C#", new[] { ".cs" }, "CSharp-Mode.xshd");
 
-            //hlm.RegisterHighlighting("JavaScript", new[] { ".js" }, "JavaScript-Mode.xshd");
-            //hlm.RegisterHighlighting("HTML", new[] { ".htm", ".html" }, "HTML-Mode.xshd");
-            //hlm.RegisterHighlighting("ASP/XHTML", new[] { ".asp", ".aspx", ".asax", ".asmx", ".ascx", ".master" }, "ASPX.xshd");
+            hlm.RegisterHighlighting("JavaScript", new[] { ".js" }, "JavaScript-Mode.xshd");
+            hlm.RegisterHighlighting("HTML", new[] { ".htm", ".html" }, "HTML-Mode.xshd");
+            hlm.RegisterHighlighting("ASP/XHTML", new[] { ".asp", ".aspx", ".asax", ".asmx", ".ascx", ".master" }, "ASPX.xshd");
 
-            //hlm.RegisterHighlighting("Boo", new[] { ".boo" }, "Boo.xshd");
-            //hlm.RegisterHighlighting("Coco", new[] { ".atg" }, "Coco-Mode.xshd");
-            //hlm.RegisterHighlighting("CSS", new[] { ".css" }, "CSS-Mode.xshd");
-            //hlm.RegisterHighlighting("C++", new[] { ".c", ".h", ".cc", ".cpp", ".hpp" }, "CPP-Mode.xshd");
-            //hlm.RegisterHighlighting("Java", new[] { ".java" }, "Java-Mode.xshd");
-            //hlm.RegisterHighlighting("Patch", new[] { ".patch", ".diff" }, "Patch-Mode.xshd");
-            //hlm.RegisterHighlighting("PowerShell", new[] { ".ps1", ".psm1", ".psd1" }, "PowerShell.xshd");
-            //hlm.RegisterHighlighting("PHP", new[] { ".php" }, "PHP-Mode.xshd");
-            //hlm.RegisterHighlighting("TeX", new[] { ".tex" }, "Tex-Mode.xshd");
-            //hlm.RegisterHighlighting("VB", new[] { ".vb" }, "VB-Mode.xshd");
-            //hlm.RegisterHighlighting("XML", (".xml;.xsl;.xslt;.xsd;.manifest;.config;.addin;" +
-            //                                 ".xshd;.wxs;.wxi;.wxl;.proj;.csproj;.vbproj;.ilproj;" +
-            //                                 ".booproj;.build;.xfrm;.targets;.xaml;.xpt;" +
-            //                                 ".xft;.map;.wsdl;.disco;.ps1xml;.nuspec").Split(';'),
-            //                         "XML-Mode.xshd");
+            hlm.RegisterHighlighting("Boo", new[] { ".boo" }, "Boo.xshd");
+            hlm.RegisterHighlighting("Coco", new[] { ".atg" }, "Coco-Mode.xshd");
+            hlm.RegisterHighlighting("CSS", new[] { ".css" }, "CSS-Mode.xshd");
+            hlm.RegisterHighlighting("C++", new[] { ".c", ".h", ".cc", ".cpp", ".hpp" }, "CPP-Mode.xshd");
+            hlm.RegisterHighlighting("Java", new[] { ".java" }, "Java-Mode.xshd");
+            hlm.RegisterHighlighting("Patch", new[] { ".patch", ".diff" }, "Patch-Mode.xshd");
+            hlm.RegisterHighlighting("PowerShell", new[] { ".ps1", ".psm1", ".psd1" }, "PowerShell.xshd");
+            hlm.RegisterHighlighting("PHP", new[] { ".php" }, "PHP-Mode.xshd");
+            hlm.RegisterHighlighting("TeX", new[] { ".tex" }, "Tex-Mode.xshd");
+            hlm.RegisterHighlighting("VB", new[] { ".vb" }, "VB-Mode.xshd");
+            hlm.RegisterHighlighting("XML", (".xml;.xsl;.xslt;.xsd;.manifest;.config;.addin;" +
+                                             ".xshd;.wxs;.wxi;.wxl;.proj;.csproj;.vbproj;.ilproj;" +
+                                             ".booproj;.build;.xfrm;.targets;.xaml;.xpt;" +
+                                             ".xft;.map;.wsdl;.disco;.ps1xml;.nuspec").Split(';'),
+                                     "XML-Mode.xshd");
             hlm.RegisterHighlighting("MarkDown", new[] { ".md" }, "MarkDown-Mode.xshd");
 		}
 	}

--- a/ICSharpCode.AvalonEdit/Highlighting/Xshd/V2Loader.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/Xshd/V2Loader.cs
@@ -298,24 +298,46 @@ namespace ICSharpCode.AvalonEdit.Highlighting.Xshd
 			color.FontWeight = ParseFontWeight(reader.GetAttribute("fontWeight"));
 			color.FontStyle = ParseFontStyle(reader.GetAttribute("fontStyle"));
 			color.Underline = reader.GetBoolAttribute("underline");
-			return color;
+            color.FontFamily = ParseFontFamily(position, reader.GetAttribute("fontFamily"));
+            color.FontSize = ParseFontSize(position, reader.GetAttribute("fontSize"));
+            return color;
 		}
 		
 		internal readonly static ColorConverter ColorConverter = new ColorConverter();
 		internal readonly static FontWeightConverter FontWeightConverter = new FontWeightConverter();
 		internal readonly static FontStyleConverter FontStyleConverter = new FontStyleConverter();
-		
-		static HighlightingBrush ParseColor(IXmlLineInfo lineInfo, string color)
-		{
-			if (string.IsNullOrEmpty(color))
-				return null;
-			if (color.StartsWith("SystemColors.", StringComparison.Ordinal))
-				return GetSystemColorBrush(lineInfo, color);
-			else
-				return FixedColorHighlightingBrush((Color?)ColorConverter.ConvertFromInvariantString(color));
-		}
-		
-		internal static SystemColorHighlightingBrush GetSystemColorBrush(IXmlLineInfo lineInfo, string name)
+
+        static HighlightingBrush ParseColor(IXmlLineInfo lineInfo, string color)
+        {
+            if (string.IsNullOrEmpty(color))
+                return null;
+            if (color.StartsWith("SystemColors.", StringComparison.Ordinal))
+                return GetSystemColorBrush(lineInfo, color);
+            else
+                return FixedColorHighlightingBrush((Color?)ColorConverter.ConvertFromInvariantString(color));
+        }
+
+        static int? ParseFontSize(IXmlLineInfo lineInfo, string size)
+        {
+            int value;
+            return int.TryParse(size, out value)
+                ? value
+                : (int?)null;
+        }
+
+        static FontFamily ParseFontFamily(IXmlLineInfo lineInfo, string family)
+        {
+            if (!string.IsNullOrEmpty(family))
+            {
+                return new FontFamily(family);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        internal static SystemColorHighlightingBrush GetSystemColorBrush(IXmlLineInfo lineInfo, string name)
 		{
 			Debug.Assert(name.StartsWith("SystemColors.", StringComparison.Ordinal));
 			string shortName = name.Substring(13);

--- a/ICSharpCode.AvalonEdit/Highlighting/Xshd/XmlHighlightingDefinition.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/Xshd/XmlHighlightingDefinition.cs
@@ -207,6 +207,8 @@ namespace ICSharpCode.AvalonEdit.Highlighting.Xshd
 				c.Underline = color.Underline;
 				c.FontStyle = color.FontStyle;
 				c.FontWeight = color.FontWeight;
+                c.FontFamily = color.FontFamily;
+                c.FontSize = color.FontSize;
 				return c;
 			}
 			

--- a/ICSharpCode.AvalonEdit/Highlighting/Xshd/XshdColor.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/Xshd/XshdColor.cs
@@ -17,9 +17,11 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Security.Permissions;
 using System.Windows;
+using System.Windows.Media;
 
 namespace ICSharpCode.AvalonEdit.Highlighting.Xshd
 {
@@ -33,11 +35,21 @@ namespace ICSharpCode.AvalonEdit.Highlighting.Xshd
 		/// Gets/sets the name.
 		/// </summary>
 		public string Name { get; set; }
-		
-		/// <summary>
-		/// Gets/sets the foreground brush.
-		/// </summary>
-		public HighlightingBrush Foreground { get; set; }
+
+        /// <summary>
+        /// Gets/sets the font family
+        /// </summary>
+        public FontFamily FontFamily { get; set; }
+
+        /// <summary>
+        /// Gets/sets the font size.
+        /// </summary>
+        public int? FontSize { get; set; }
+
+        /// <summary>
+        /// Gets/sets the foreground brush.
+        /// </summary>
+        public HighlightingBrush Foreground { get; set; }
 		
 		/// <summary>
 		/// Gets/sets the background brush.
@@ -88,6 +100,10 @@ namespace ICSharpCode.AvalonEdit.Highlighting.Xshd
 			this.ExampleText = info.GetString("ExampleText");
 			if (info.GetBoolean("HasUnderline"))
 				this.Underline = info.GetBoolean("Underline");
+            if (info.GetBoolean("HasFamily"))
+                this.FontFamily = new FontFamily(info.GetString("Family"));
+            if (info.GetBoolean("HasSize"))
+                this.FontSize = info.GetInt32("Size");
 		}
 		
 		/// <summary>
@@ -115,10 +131,16 @@ namespace ICSharpCode.AvalonEdit.Highlighting.Xshd
 			if (this.FontStyle.HasValue)
 				info.AddValue("Style", this.FontStyle.Value.ToString());
 			info.AddValue("ExampleText", this.ExampleText);
-		}
-		
-		/// <inheritdoc/>
-		public override object AcceptVisitor(IXshdVisitor visitor)
+            info.AddValue("HasFamily", this.FontFamily != null);
+            if (this.FontFamily != null)
+                info.AddValue("Family", this.FontFamily.FamilyNames.FirstOrDefault());
+            info.AddValue("HasSize", this.FontSize.HasValue);
+            if (this.FontSize.HasValue)
+                info.AddValue("Size", this.FontSize.Value.ToString());
+        }
+
+        /// <inheritdoc/>
+        public override object AcceptVisitor(IXshdVisitor visitor)
 		{
 			return visitor.VisitColor(this);
 		}

--- a/ICSharpCode.AvalonEdit/Highlighting/Xshd/XshdColor.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/Xshd/XshdColor.cs
@@ -37,16 +37,6 @@ namespace ICSharpCode.AvalonEdit.Highlighting.Xshd
 		public string Name { get; set; }
 
         /// <summary>
-        /// Gets/sets the font family
-        /// </summary>
-        public FontFamily FontFamily { get; set; }
-
-        /// <summary>
-        /// Gets/sets the font size.
-        /// </summary>
-        public int? FontSize { get; set; }
-
-        /// <summary>
         /// Gets/sets the foreground brush.
         /// </summary>
         public HighlightingBrush Foreground { get; set; }
@@ -70,11 +60,21 @@ namespace ICSharpCode.AvalonEdit.Highlighting.Xshd
 		/// Gets/sets the font style.
 		/// </summary>
 		public FontStyle? FontStyle { get; set; }
-		
-		/// <summary>
-		/// Gets/Sets the example text that demonstrates where the color is used.
-		/// </summary>
-		public string ExampleText { get; set; }
+
+        /// <summary>
+        /// Gets/sets the font family
+        /// </summary>
+        public FontFamily FontFamily { get; set; }
+
+        /// <summary>
+        /// Gets/sets the font size.
+        /// </summary>
+        public int? FontSize { get; set; }
+
+        /// <summary>
+        /// Gets/Sets the example text that demonstrates where the color is used.
+        /// </summary>
+        public string ExampleText { get; set; }
 		
 		/// <summary>
 		/// Creates a new XshdColor instance.

--- a/ICSharpCode.AvalonEdit/Highlighting/Xshd/XshdColor.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/Xshd/XshdColor.cs
@@ -133,7 +133,7 @@ namespace ICSharpCode.AvalonEdit.Highlighting.Xshd
 			info.AddValue("ExampleText", this.ExampleText);
             info.AddValue("HasFamily", this.FontFamily != null);
             if (this.FontFamily != null)
-                info.AddValue("Family", this.FontFamily.FamilyNames.FirstOrDefault());
+                info.AddValue("Family", this.FontFamily.Source);
             info.AddValue("HasSize", this.FontSize.HasValue);
             if (this.FontSize.HasValue)
                 info.AddValue("Size", this.FontSize.Value.ToString());


### PR DESCRIPTION
# Added syntax highlighting options for styling font-family and font-size

I've added `FontFamily` and `FontSize` enumerations to _ModeV2.xsd_ and their related properties to `XshdColor.cs` and `HighlightingColor.cs`.

`HighlightingColorizer.cs` has been amended to apply the new values to `element.TextRunProperties`.

I've enhanced _Markdown-Mode.xshd_ to demo the new settings which can be viewed in the sample app by changing the highlighting option to _Markdown_ and inserting the following text:

```
# Heading1
## Heading2
### Heading3
#### Heading4
##### Heading5
###### Heading6
```
### Before:

![markdownbefore](https://cloud.githubusercontent.com/assets/4510990/9873585/c5508390-5b98-11e5-8436-b0ec56ebb3ce.png)
### After:

![markdown3](https://cloud.githubusercontent.com/assets/4510990/9917753/3d0defc6-5cbb-11e5-8d48-401ed8a12cf0.png)

I chose to restrict the values for `FontFamily` and `FontSize` in _ModeV2.xsd_

``` xml
<!-- Font Size -->
<xsd:simpleType name="FontSize">
  <xsd:restriction base="xsd:integer">
    <xsd:enumeration value="8"/>
    <xsd:enumeration value="9"/>
    <xsd:enumeration value="10"/>
    <xsd:enumeration value="12"/>
    <xsd:enumeration value="14"/>
    <xsd:enumeration value="16"/>
    <xsd:enumeration value="18"/>
    <xsd:enumeration value="20"/>
    <xsd:enumeration value="22"/>
    <xsd:enumeration value="24"/>
    <xsd:enumeration value="26"/>
    <xsd:enumeration value="28"/>
    <xsd:enumeration value="36"/>
    <xsd:enumeration value="48"/>
    <xsd:enumeration value="72"/>
  </xsd:restriction>
</xsd:simpleType>

<!-- Font Family -->
<xsd:simpleType name="FontFamily">
  <xsd:restriction base="xsd:string">
    <xsd:enumeration value="Georgia, serif"/>
    <xsd:enumeration value="Palatino Linotype, Book Antiqua, Palatino, serif"/>
    <xsd:enumeration value="Times New Roman, Times, serif"/>
    <xsd:enumeration value="Arial, Helvetica, sans-serif"/>
    <xsd:enumeration value="Arial Black, Gadget, sans-serif"/>
    <xsd:enumeration value="Comic Sans MS, cursive, sans-serif"/>
    <xsd:enumeration value="Impact, Charcoal, sans-serif"/>
    <xsd:enumeration value="Lucida Sans Unicode, Lucida Grande, sans-serif"/>
    <xsd:enumeration value="Tahoma, Geneva, sans-serif"/>
    <xsd:enumeration value="Trebuchet MS, Helvetica, sans-serif"/>
    <xsd:enumeration value="Verdana, Geneva, sans-serif"/>
    <xsd:enumeration value="Courier New, Courier, monospace"/>
    <xsd:enumeration value="Lucida Console, Monaco, monospace"/>
  </xsd:restriction>
</xsd:simpleType>
```
