### PR TITLE
Fixed missing border in TextEditor template

### DIFF
--- a/ICSharpCode.AvalonEdit/TextEditor.xaml
+++ b/ICSharpCode.AvalonEdit/TextEditor.xaml
@@ -1,8 +1,7 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:AvalonEdit="clr-namespace:ICSharpCode.AvalonEdit"
-	xmlns:editing="clr-namespace:ICSharpCode.AvalonEdit.Editing"
->
+	xmlns:editing="clr-namespace:ICSharpCode.AvalonEdit.Editing">
 	<Style TargetType="{x:Type AvalonEdit:TextEditor}">
 		<Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" />
 		<Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" />
@@ -10,21 +9,20 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="{x:Type AvalonEdit:TextEditor}">
-					<ScrollViewer
-						Focusable="False"
-						Name="PART_ScrollViewer"
-						CanContentScroll="True"
-						VerticalScrollBarVisibility="{TemplateBinding VerticalScrollBarVisibility}"
-						HorizontalScrollBarVisibility="{TemplateBinding HorizontalScrollBarVisibility}"
-						Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TextArea}"
-						VerticalContentAlignment="Top"
-						HorizontalContentAlignment="Left"
-						Background="{TemplateBinding Background}"
-						Padding="{TemplateBinding Padding}"
-						BorderBrush="{TemplateBinding BorderBrush}"
-						BorderThickness="{TemplateBinding BorderThickness}"
-					/>
-					<ControlTemplate.Triggers>
+          <Border Background="{TemplateBinding Background}"
+                  BorderBrush="{TemplateBinding BorderBrush}"
+                  BorderThickness="{TemplateBinding BorderThickness}">
+            <ScrollViewer Name="PART_ScrollViewer"
+                          Focusable="False"
+                          CanContentScroll="True"
+                          VerticalScrollBarVisibility="{TemplateBinding VerticalScrollBarVisibility}"
+                          HorizontalScrollBarVisibility="{TemplateBinding HorizontalScrollBarVisibility}"
+                          Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TextArea}"
+                          VerticalContentAlignment="Top"
+                          HorizontalContentAlignment="Left"
+                          Padding="{TemplateBinding Padding}"/>
+          </Border>
+          <ControlTemplate.Triggers>
 						<Trigger Property="WordWrap"
 						         Value="True">
 							<Setter TargetName="PART_ScrollViewer"
@@ -36,7 +34,7 @@
 			</Setter.Value>
 		</Setter>
 	</Style>
-	
+
 	<Style TargetType="{x:Type editing:TextArea}" x:Shared="False">
 		<Setter Property="FocusVisualStyle" Value="{x:Null}"/>
 		<Setter Property="SelectionBrush">


### PR DESCRIPTION
Setting the `BorderBrush` and `BorderThickness` properties on the `TextEditor` doesn't currently work because they are bound to the `ScrollViewer`. AFAIK the default template for the `ScrollViewer` doesn't contain a `Border`, therefore they have no effect.

I fixed the issue by wrapping the `ScrollViewer` in a `Border`, and set the template bindings for the respective properties on the `Border` rather than the `ScrollViewer`. This includes the `Background` property.

PS: Sorry for the bad formatting, you'd consider adding a .editorconfig to the project. ;)