### PR TITLE
Fix parameter to Replace

### DIFF
--- a/ICSharpCode.AvalonEdit/Indentation/DefaultIndentationStrategy.cs
+++ b/ICSharpCode.AvalonEdit/Indentation/DefaultIndentationStrategy.cs
@@ -41,7 +41,7 @@ namespace ICSharpCode.AvalonEdit.Indentation
 				string indentation = document.GetText(indentationSegment);
 				// copy indentation to line
 				indentationSegment = TextUtilities.GetWhitespaceAfter(document, line.Offset);
-				document.Replace(indentationSegment.Offset, indentation.Length, indentation,
+				document.Replace(indentationSegment.Offset, indentationSegment.Length, indentation,
 				                 OffsetChangeMappingType.RemoveAndInsert);
 				// OffsetChangeMappingType.RemoveAndInsert guarantees the caret moves behind the new indentation.
 			}


### PR DESCRIPTION
Fixing a bug: the 2nd parameter of Replace is supposed to be the length of the text to replace (i.e. selection) instead of the length of the indentation string.