### PR TITLE
Fix default closed regions

### DIFF
--- a/ICSharpCode.AvalonEdit/Folding/FoldingManager.cs
+++ b/ICSharpCode.AvalonEdit/Folding/FoldingManager.cs
@@ -279,7 +279,6 @@ namespace ICSharpCode.AvalonEdit.Folding
 					// auto-close #regions only when opening the document
 					if (isFirstUpdate) {
 						section.IsFolded = newFolding.DefaultClosed;
-						isFirstUpdate = false;
 					}
 					section.Tag = newFolding;
 				}
@@ -292,6 +291,7 @@ namespace ICSharpCode.AvalonEdit.Folding
 					break;
 				this.RemoveFolding(oldSection);
 			}
+            isFirstUpdate = false;
 		}
 		#endregion
 		

--- a/ICSharpCode.AvalonEdit/Folding/FoldingManager.cs
+++ b/ICSharpCode.AvalonEdit/Folding/FoldingManager.cs
@@ -291,7 +291,7 @@ namespace ICSharpCode.AvalonEdit.Folding
 					break;
 				this.RemoveFolding(oldSection);
 			}
-            isFirstUpdate = false;
+			isFirstUpdate = false;
 		}
 		#endregion
 		


### PR DESCRIPTION
When creating several NewRegion's with DefaultClosed=true, in the editor only the first region is closed. All other is opened.
