### PR TITLE
Added strikethrough to syntax highlighting options

### DIFF
--- a/ICSharpCode.AvalonEdit/Highlighting/HighlightingColor.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/HighlightingColor.cs
@@ -39,7 +39,8 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 		FontWeight? fontWeight;
 		FontStyle? fontStyle;
 		bool? underline;
-		HighlightingBrush foreground;
+		bool? strikethrough;
+        HighlightingBrush foreground;
 		HighlightingBrush background;
 		bool frozen;
 		
@@ -97,12 +98,29 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 					throw new InvalidOperationException();
 				underline = value;
 			}
-		}
-		
-		/// <summary>
-		/// Gets/sets the foreground color applied by the highlighting.
-		/// </summary>
-		public HighlightingBrush Foreground {
+        }
+
+        /// <summary>
+        ///  Gets/sets the strikethrough flag. Null if the strikethrough status does not change the font style.
+        /// </summary>
+        public bool? Strikethrough
+        {
+            get
+            {
+                return strikethrough;
+            }
+            set
+            {
+                if (frozen)
+                    throw new InvalidOperationException();
+                strikethrough = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets/sets the foreground color applied by the highlighting.
+        /// </summary>
+        public HighlightingBrush Foreground {
 			get {
 				return foreground;
 			}
@@ -148,7 +166,9 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 				this.FontStyle = (FontStyle?)new FontStyleConverter().ConvertFromInvariantString(info.GetString("Style"));
 			if (info.GetBoolean("HasUnderline"))
 				this.Underline = info.GetBoolean("Underline");
-			this.Foreground = (HighlightingBrush)info.GetValue("Foreground", typeof(HighlightingBrush));
+            if (info.GetBoolean("HasStrikethrough"))
+                this.Strikethrough = info.GetBoolean("Strikethrough");
+            this.Foreground = (HighlightingBrush)info.GetValue("Foreground", typeof(HighlightingBrush));
 			this.Background = (HighlightingBrush)info.GetValue("Background", typeof(HighlightingBrush));
 		}
 		
@@ -174,7 +194,9 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 			info.AddValue("HasUnderline", this.Underline.HasValue);
 			if (this.Underline.HasValue)
 				info.AddValue("Underline", this.Underline.Value);
-			info.AddValue("Foreground", this.Foreground);
+            if (this.Strikethrough.HasValue)
+                info.AddValue("Strikethrough", this.Strikethrough.Value);
+            info.AddValue("Foreground", this.Foreground);
 			info.AddValue("Background", this.Background);
 		}
 		
@@ -207,7 +229,16 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 				b.Append(Underline.Value ? "underline" : "none");
 				b.Append("; ");
 			}
-			return b.ToString();
+            if (Strikethrough != null)
+            {
+                if (Underline == null)
+                    b.Append("text-decoration:  ");
+
+                b.Remove(b.Length - 1, 1);
+                b.Append(Strikethrough.Value ? " line-through" : " none");
+                b.Append("; ");
+            }
+            return b.ToString();
 		}
 		
 		/// <inheritdoc/>
@@ -260,6 +291,7 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 				return false;
 			return this.name == other.name && this.fontWeight == other.fontWeight
 				&& this.fontStyle == other.fontStyle && this.underline == other.underline
+                && this.Strikethrough == other.Strikethrough
 				&& object.Equals(this.foreground, other.foreground) && object.Equals(this.background, other.background);
 		}
 		
@@ -297,12 +329,14 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 				this.background = color.background;
 			if (color.underline != null)
 				this.underline = color.underline;
-		}
+            if (color.strikethrough != null)
+                this.strikethrough = color.strikethrough;
+        }
 		
 		internal bool IsEmptyForMerge {
 			get {
 				return fontWeight == null && fontStyle == null && underline == null
-					&& foreground == null && background == null;
+					&& strikethrough == null && foreground == null && background == null;
 			}
 		}
 	}

--- a/ICSharpCode.AvalonEdit/Highlighting/HighlightingColorizer.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/HighlightingColorizer.cs
@@ -233,7 +233,7 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 				return true;
 			return color.Background == null && color.Foreground == null
 				&& color.FontStyle == null && color.FontWeight == null
-				&& color.Underline == null;
+				&& color.Underline == null && color.Strikethrough == null;
 		}
 		
 		/// <summary>
@@ -267,7 +267,9 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 			}
 			if(color.Underline ?? false)
 				element.TextRunProperties.SetTextDecorations(TextDecorations.Underline);
-		}
+            if (color.Strikethrough ?? false)
+                element.TextRunProperties.SetTextDecorations(TextDecorations.Strikethrough);
+        }
 		
 		/// <summary>
 		/// This method is responsible for telling the TextView to redraw lines when the highlighting state has changed.

--- a/ICSharpCode.AvalonEdit/Highlighting/Resources/ModeV2.xsd
+++ b/ICSharpCode.AvalonEdit/Highlighting/Resources/ModeV2.xsd
@@ -35,7 +35,8 @@
 		<xsd:attribute name="background" type="xsd:string" use="optional" />
 		<xsd:attribute name="fontWeight" type="FontWeight" use="optional" />
 		<xsd:attribute name="fontStyle" type="FontStyle" use="optional" />
-		<xsd:attribute name="underline" type="xsd:boolean" use="optional" />
+    <xsd:attribute name="underline" type="xsd:boolean" use="optional" />
+    <xsd:attribute name="strikethrough" type="xsd:boolean" use="optional" />
 		<xsd:anyAttribute namespace="##other" processContents="lax" />
 	</xsd:attributeGroup>
 	

--- a/ICSharpCode.AvalonEdit/Highlighting/Xshd/V2Loader.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/Xshd/V2Loader.cs
@@ -298,7 +298,8 @@ namespace ICSharpCode.AvalonEdit.Highlighting.Xshd
 			color.FontWeight = ParseFontWeight(reader.GetAttribute("fontWeight"));
 			color.FontStyle = ParseFontStyle(reader.GetAttribute("fontStyle"));
 			color.Underline = reader.GetBoolAttribute("underline");
-			return color;
+			color.Strikethrough = reader.GetBoolAttribute("strikethrough");
+            return color;
 		}
 		
 		internal readonly static ColorConverter ColorConverter = new ColorConverter();

--- a/ICSharpCode.AvalonEdit/Highlighting/Xshd/XmlHighlightingDefinition.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/Xshd/XmlHighlightingDefinition.cs
@@ -205,7 +205,8 @@ namespace ICSharpCode.AvalonEdit.Highlighting.Xshd
 				c.Foreground = color.Foreground;
 				c.Background = color.Background;
 				c.Underline = color.Underline;
-				c.FontStyle = color.FontStyle;
+				c.Strikethrough = color.Strikethrough;
+                c.FontStyle = color.FontStyle;
 				c.FontWeight = color.FontWeight;
 				return c;
 			}

--- a/ICSharpCode.AvalonEdit/Highlighting/Xshd/XshdColor.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/Xshd/XshdColor.cs
@@ -53,11 +53,16 @@ namespace ICSharpCode.AvalonEdit.Highlighting.Xshd
 		/// Gets/sets the underline flag
 		/// </summary>
 		public bool? Underline { get; set; }
-		
-		/// <summary>
-		/// Gets/sets the font style.
-		/// </summary>
-		public FontStyle? FontStyle { get; set; }
+
+        /// <summary>
+        /// Gets/sets the strikethrough flag
+        /// </summary>
+        public bool? Strikethrough { get; set; }
+
+        /// <summary>
+        /// Gets/sets the font style.
+        /// </summary>
+        public FontStyle? FontStyle { get; set; }
 		
 		/// <summary>
 		/// Gets/Sets the example text that demonstrates where the color is used.
@@ -88,7 +93,9 @@ namespace ICSharpCode.AvalonEdit.Highlighting.Xshd
 			this.ExampleText = info.GetString("ExampleText");
 			if (info.GetBoolean("HasUnderline"))
 				this.Underline = info.GetBoolean("Underline");
-		}
+            if (info.GetBoolean("HasStrikethrough"))
+                this.Strikethrough = info.GetBoolean("Strikethrough");
+        }
 		
 		/// <summary>
 		/// Serializes this XshdColor instance.
@@ -108,7 +115,10 @@ namespace ICSharpCode.AvalonEdit.Highlighting.Xshd
 			info.AddValue("HasUnderline", this.Underline.HasValue);
 			if (this.Underline.HasValue)
 				info.AddValue("Underline", this.Underline.Value);
-			info.AddValue("HasWeight", this.FontWeight.HasValue);
+            info.AddValue("HasStrikethrough", this.Strikethrough.HasValue);
+            if (this.Strikethrough.HasValue)
+                info.AddValue("Strikethrough", this.Strikethrough.Value);
+            info.AddValue("HasWeight", this.FontWeight.HasValue);
 			if (this.FontWeight.HasValue)
 				info.AddValue("Weight", this.FontWeight.Value.ToOpenTypeWeight());
 			info.AddValue("HasStyle", this.FontStyle.HasValue);

--- a/ICSharpCode.AvalonEdit/Rendering/VisualLineElementTextRunProperties.cs
+++ b/ICSharpCode.AvalonEdit/Rendering/VisualLineElementTextRunProperties.cs
@@ -22,6 +22,7 @@ using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.TextFormatting;
 using ICSharpCode.AvalonEdit.Utils;
+using System.Linq;
 
 namespace ICSharpCode.AvalonEdit.Rendering
 {
@@ -200,8 +201,12 @@ namespace ICSharpCode.AvalonEdit.Rendering
 		public void SetTextDecorations(TextDecorationCollection value)
 		{
 			ExtensionMethods.CheckIsFrozen(value);
-			textDecorations = value;
-		}
+
+            if (textDecorations == null)
+                textDecorations = value;
+            else
+                textDecorations = new TextDecorationCollection(textDecorations.Union(value));
+        }
 		
 		/// <summary>
 		/// Gets the text effects. The value may be null, a frozen <see cref="TextEffectCollection"/>


### PR DESCRIPTION
I've added a new option for `strikethrough` text decorations to syntax
highlighting.

It will work in the same manner as the underline option when setting up
the xshd template file. It can be used with underline, they're not
exclusive.
