### PR TITLE
[WIP] Add SwapLinesUp/Down commands with Alt+Up/Down

### DIFF
--- a/ICSharpCode.AvalonEdit/AvalonEditCommands.cs
+++ b/ICSharpCode.AvalonEdit/AvalonEditCommands.cs
@@ -45,7 +45,27 @@ namespace ICSharpCode.AvalonEdit
 			new InputGestureCollection {
 				new KeyGesture(Key.D, ModifierKeys.Control)
 			});
-		
+
+		/// <summary>
+		/// Swap the current line and the previous line.
+		/// The default shortcut is Alt+Up.
+		/// </summary>
+		public static readonly RoutedCommand SwapLinesUp = new RoutedCommand(
+			"SwapLinesUp", typeof(TextEditor),
+			new InputGestureCollection {
+				new KeyGesture(Key.Up, ModifierKeys.Alt)
+			});
+
+		/// <summary>
+		/// Swap the current line and the next line.
+		/// The default shortcut is Alt+Down.
+		/// </summary>
+		public static readonly RoutedCommand SwapLinesDown = new RoutedCommand(
+			"SwapLinesDown", typeof(TextEditor),
+			new InputGestureCollection {
+				new KeyGesture(Key.Down, ModifierKeys.Alt)
+			});
+
 		/// <summary>
 		/// Removes leading whitespace from the selected lines (or the whole document if the selection is empty).
 		/// </summary>

--- a/ICSharpCode.AvalonEdit/Editing/EditingCommandHandler.cs
+++ b/ICSharpCode.AvalonEdit/Editing/EditingCommandHandler.cs
@@ -776,22 +776,22 @@ namespace ICSharpCode.AvalonEdit.Editing
 		public SelectionPreserver(TextArea textArea)
 			: base(textArea)
 		{
-			startPosition = textArea.Selection.StartPosition;
-			endPosition = textArea.Selection.EndPosition;
+			startLocation = textArea.Selection.StartPosition.Location;
+			endLocation = textArea.Selection.EndPosition.Location;
 		}
 
 		public override void Restore()
 		{
-			TextArea.Selection = Selection.Create(TextArea, startPosition, endPosition);
+			TextArea.Selection = Selection.Create(TextArea, new TextViewPosition(startLocation), new TextViewPosition(endLocation));
 		}
 
 		public override void MoveLine(int i)
 		{
-			startPosition = new TextViewPosition(startPosition.Line + i, startPosition.Column);
-			endPosition = new TextViewPosition(endPosition.Line + i, endPosition.Column);
+			startLocation = new TextLocation(startLocation.Line + i, startLocation.Column);
+			endLocation = new TextLocation(endLocation.Line + i, endLocation.Column);
 		}
 
-		TextViewPosition startPosition, endPosition;
+		TextLocation startLocation, endLocation;
 	}
 
 	struct SelectionLineRange


### PR DESCRIPTION
## Feature

Swap the lines of selection with the adjucent one.

This is same as Alt+Up/Down in Visual Studio, Ctrl+Shift+Up/Down in Sublime Text, etc.
## Sample

```
zzzz
xx<caret/>xx
wwww

     ↓ Alt+Up ↓

xx<caret/>xx
zzzz
wwww
```

And with selection.

```
zzzz
xxx<selection>yyy
yyyy</selection>xxxx
wwww

     ↓ Alt+Up ↓

xxx<selection>yyy
yyyy</selection>xxxx
zzzz
wwww
```
## Issue

I'm now stuck with how to implement "selection restoration". I want to preserve the state of selection after executing the commands as I examplified above. In current implementation, the selection is cleared.
- [ ] Selection Restoration
