### PR TITLE
Detect mouse capture loss during text selection

### DIFF
--- a/ICSharpCode.AvalonEdit/Editing/SelectionMouseHandler.cs
+++ b/ICSharpCode.AvalonEdit/Editing/SelectionMouseHandler.cs
@@ -89,21 +89,21 @@ namespace ICSharpCode.AvalonEdit.Editing
 			this.textArea = textArea;
 		}
 		
-        static SelectionMouseHandler()
-        {
-            EventManager.RegisterClassHandler(typeof(TextArea), Mouse.LostMouseCaptureEvent, new MouseEventHandler(OnLostMouseCapture));
-        }
+		static SelectionMouseHandler()
+		{
+			EventManager.RegisterClassHandler(typeof(TextArea), Mouse.LostMouseCaptureEvent, new MouseEventHandler(OnLostMouseCapture));
+		}
 
-        private static void OnLostMouseCapture(object sender, MouseEventArgs e)
-        {
-            TextArea textArea = (TextArea)sender;
-            if (Mouse.Captured != textArea)
-            {
-                SelectionMouseHandler handler = textArea.DefaultInputHandler.NestedInputHandlers.OfType<SelectionMouseHandler>().FirstOrDefault();
-                if (handler != null)
-                    handler.mode = SelectionMode.None;
-            }
-        }
+		private static void OnLostMouseCapture(object sender, MouseEventArgs e)
+		{
+			TextArea textArea = (TextArea)sender;
+			if (Mouse.Captured != textArea)
+			{
+				SelectionMouseHandler handler = textArea.DefaultInputHandler.NestedInputHandlers.OfType<SelectionMouseHandler>().FirstOrDefault();
+				if (handler != null)
+					handler.mode = SelectionMode.None;
+			}
+		}
 
 		public TextArea TextArea {
 			get { return textArea; }

--- a/ICSharpCode.AvalonEdit/Editing/SelectionMouseHandler.cs
+++ b/ICSharpCode.AvalonEdit/Editing/SelectionMouseHandler.cs
@@ -99,7 +99,7 @@ namespace ICSharpCode.AvalonEdit.Editing
 			TextArea textArea = (TextArea)sender;
 			if (Mouse.Captured != textArea)
 			{
-				SelectionMouseHandler handler = textArea.DefaultInputHandler.NestedInputHandlers.OfType<SelectionMouseHandler>().FirstOrDefault();
+				SelectionMouseHandler handler = textArea.DefaultInputHandler.MouseSelection as SelectionMouseHandler;
 				if (handler != null)
 					handler.mode = SelectionMode.None;
 			}

--- a/ICSharpCode.AvalonEdit/Editing/SelectionMouseHandler.cs
+++ b/ICSharpCode.AvalonEdit/Editing/SelectionMouseHandler.cs
@@ -89,6 +89,22 @@ namespace ICSharpCode.AvalonEdit.Editing
 			this.textArea = textArea;
 		}
 		
+        static SelectionMouseHandler()
+        {
+            EventManager.RegisterClassHandler(typeof(TextArea), Mouse.LostMouseCaptureEvent, new MouseEventHandler(OnLostMouseCapture));
+        }
+
+        private static void OnLostMouseCapture(object sender, MouseEventArgs e)
+        {
+            TextArea textArea = (TextArea)sender;
+            if (Mouse.Captured != textArea)
+            {
+                SelectionMouseHandler handler = textArea.DefaultInputHandler.NestedInputHandlers.OfType<SelectionMouseHandler>().FirstOrDefault();
+                if (handler != null)
+                    handler.mode = SelectionMode.None;
+            }
+        }
+
 		public TextArea TextArea {
 			get { return textArea; }
 		}


### PR DESCRIPTION
There may be times when SelectionMouseHandler detects a left mouse button down event on its TextArea, but then immediately the mouse capture is lost, and SelectionMouseHandler does not reset the selection mode. 

I noticed this when I started showing a dialog in response to my main window being activated, if I have detected that the file being edited by the user was changed by another process. When I activate my application by clicking on the editor, the SelectionMouseHandler detects this and begins selecting text. But immediately the TextArea loses mouse capture, as in my handler I show a modal dialog. When the user dismisses this dialog, even though the left mouse button is no longer pressed, moving the mouse around extends the selection as if it were.

I mimic exactly the approach in the source code for System.Windows.Controls.Primitives.Thumb, the only difference being that here I have to go looking for the SelectionMouseHandler that is associated with the TextArea in the sender parameter. Perhaps there is a more direct way of finding it, though this seems to work for me.
