### PR TITLE
Ensure search options panel is closed when search panel is closed

### DIFF
--- a/ICSharpCode.AvalonEdit/Search/SearchPanel.cs
+++ b/ICSharpCode.AvalonEdit/Search/SearchPanel.cs
@@ -46,6 +46,7 @@ namespace ICSharpCode.AvalonEdit.Search
 		TextDocument currentDocument;
 		SearchResultBackgroundRenderer renderer;
 		TextBox searchTextBox;
+		Popup dropdownPopup;
 		SearchPanelAdorner adorner;
 		
 		#region DependencyProperties
@@ -275,7 +276,9 @@ namespace ICSharpCode.AvalonEdit.Search
 		public override void OnApplyTemplate()
 		{
 			base.OnApplyTemplate();
+			
 			searchTextBox = Template.FindName("PART_searchTextBox", this) as TextBox;
+			dropdownPopup = Template.FindName("PART_dropdownPopup", this) as Popup;
 		}
 		
 		void ValidateSearchText()
@@ -411,6 +414,8 @@ namespace ICSharpCode.AvalonEdit.Search
 			var layer = AdornerLayer.GetAdornerLayer(textArea);
 			if (layer != null)
 				layer.Remove(adorner);
+			if (dropdownPopup != null)
+            	dropdownPopup.IsOpen = false;
 			messageView.IsOpen = false;
 			textArea.TextView.BackgroundRenderers.Remove(renderer);
 			if (hasFocus)

--- a/ICSharpCode.AvalonEdit/Search/SearchPanel.cs
+++ b/ICSharpCode.AvalonEdit/Search/SearchPanel.cs
@@ -415,7 +415,7 @@ namespace ICSharpCode.AvalonEdit.Search
 			if (layer != null)
 				layer.Remove(adorner);
 			if (dropdownPopup != null)
-            	dropdownPopup.IsOpen = false;
+				dropdownPopup.IsOpen = false;
 			messageView.IsOpen = false;
 			textArea.TextView.BackgroundRenderers.Remove(renderer);
 			if (hasFocus)

--- a/ICSharpCode.AvalonEdit/Search/SearchPanel.xaml
+++ b/ICSharpCode.AvalonEdit/Search/SearchPanel.xaml
@@ -16,8 +16,8 @@
 								</TextBox.Text>
 							</TextBox>
 							<search:DropDownButton Height="24">
-								<search:DropDownButton.DropDownContent Name="PART_dropdownPopup">
-									<Popup StaysOpen="False">
+								<search:DropDownButton.DropDownContent>
+									<Popup StaysOpen="False" Name="PART_dropdownPopup">
 										<Border Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" BorderBrush="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" BorderThickness="1">
 											<StackPanel Orientation="Vertical">
 												<CheckBox IsChecked="{Binding MatchCase, RelativeSource={RelativeSource TemplatedParent}}" Content="{Binding Localization.MatchCaseText, RelativeSource={RelativeSource TemplatedParent}}" Margin="3" />

--- a/ICSharpCode.AvalonEdit/Search/SearchPanel.xaml
+++ b/ICSharpCode.AvalonEdit/Search/SearchPanel.xaml
@@ -16,7 +16,7 @@
 								</TextBox.Text>
 							</TextBox>
 							<search:DropDownButton Height="24">
-								<search:DropDownButton.DropDownContent>
+								<search:DropDownButton.DropDownContent Name="PART_dropdownPopup">
 									<Popup StaysOpen="False">
 										<Border Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" BorderBrush="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" BorderThickness="1">
 											<StackPanel Orientation="Vertical">


### PR DESCRIPTION
I notice that if I press escape to close the search panel while the dropdown options panel is open, the latter remains open (actually, for me, it not only remains open, but jumps to the top of my screen).
