### PR TITLE
Check for valid mail URL before creating

### DIFF
--- a/ICSharpCode.AvalonEdit/Rendering/LinkElementGenerator.cs
+++ b/ICSharpCode.AvalonEdit/Rendering/LinkElementGenerator.cs
@@ -153,7 +153,11 @@ namespace ICSharpCode.AvalonEdit.Rendering
 		
 		protected override Uri GetUriFromMatch(Match match)
 		{
-			return new Uri("mailto:" + match.Value);
+			var	targetUrl =	"mailto:" +	match.Value;
+			if (Uri.IsWellFormedUriString(targetUrl, UriKind.Absolute))
+				return new Uri(targetUrl);
+
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
This fixes issue #103 , it simply adds the same type of guard in MailLinkElementGenerator that LinkElementGenerator has prior to creating a URL (as what the regex thinks is valid may differ from what Uri class does).