### PR TITLE
Fix only first fold is preserved when updating foldings

### DIFF
--- a/ICSharpCode.AvalonEdit/Folding/FoldingManager.cs
+++ b/ICSharpCode.AvalonEdit/Folding/FoldingManager.cs
@@ -279,12 +279,12 @@ namespace ICSharpCode.AvalonEdit.Folding
 					// auto-close #regions only when opening the document
 					if (isFirstUpdate) {
 						section.IsFolded = newFolding.DefaultClosed;
-						isFirstUpdate = false;
 					}
 					section.Tag = newFolding;
 				}
 				section.Title = newFolding.Name;
 			}
+			isFirstUpdate = false;
 			// remove all outstanding old foldings:
 			while (oldFoldingIndex < oldFoldings.Length) {
 				FoldingSection oldSection = oldFoldings[oldFoldingIndex++];


### PR DESCRIPTION
Issue is fixed by moving isFirstUpdate=false out of the foreach block, so that at the first update all sections get their folding state from the DefaultClosed property.
