### PR TITLE
Add null check in OnIndentSelection()

### DIFF
--- a/ICSharpCode.AvalonEdit/Editing/EditingCommandHandler.cs
+++ b/ICSharpCode.AvalonEdit/Editing/EditingCommandHandler.cs
@@ -641,7 +641,7 @@ namespace ICSharpCode.AvalonEdit.Editing
 		static void OnIndentSelection(object target, ExecutedRoutedEventArgs args)
 		{
 			TextArea textArea = GetTextArea(target);
-			if (textArea != null && textArea.Document != null) {
+			if (textArea != null && textArea.Document != null && textArea.IndentationStrategy != null) {
 				using (textArea.Document.RunUpdate()) {
 					int start, end;
 					if (textArea.Selection.IsEmpty) {


### PR DESCRIPTION
Add null check for IndentationStrategy. If this is null (not common, but can legitimately be null), pressing Ctrl+I will crash.