### PR TITLE
Fix occasional selection stutter

### DIFF
--- a/ICSharpCode.AvalonEdit/Editing/TextArea.cs
+++ b/ICSharpCode.AvalonEdit/Editing/TextArea.cs
@@ -418,18 +418,18 @@ namespace ICSharpCode.AvalonEdit.Editing
 							if (oldSegmentOffset != newSegmentOffset) {
 								textView.Redraw(Math.Min(oldSegmentOffset, newSegmentOffset),
 								                Math.Abs(oldSegmentOffset - newSegmentOffset),
-								                DispatcherPriority.Background);
+								                DispatcherPriority.Render);
 							}
 							int oldSegmentEndOffset = oldSegment.EndOffset;
 							int newSegmentEndOffset = newSegment.EndOffset;
 							if (oldSegmentEndOffset != newSegmentEndOffset) {
 								textView.Redraw(Math.Min(oldSegmentEndOffset, newSegmentEndOffset),
 								                Math.Abs(oldSegmentEndOffset - newSegmentEndOffset),
-								                DispatcherPriority.Background);
+								                DispatcherPriority.Render);
 							}
 						} else {
-							textView.Redraw(oldSegment, DispatcherPriority.Background);
-							textView.Redraw(newSegment, DispatcherPriority.Background);
+							textView.Redraw(oldSegment, DispatcherPriority.Render);
+							textView.Redraw(newSegment, DispatcherPriority.Render);
 						}
 					}
 					selection = value;


### PR DESCRIPTION
An update of the Selection property should trigger the redraw of the TextView with the appropriate DispatcherPriority. This greatly improves the selection experience and fixes occasional stutter when selecting text.