### PR TITLE
Improve block indentation behavior for C#

### DIFF
--- a/ICSharpCode.AvalonEdit/Editing/TextArea.cs
+++ b/ICSharpCode.AvalonEdit/Editing/TextArea.cs
@@ -929,6 +929,9 @@ namespace ICSharpCode.AvalonEdit.Editing
 			if (this.Document == null)
 				throw ThrowUtil.NoDocumentAssigned();
 			selection.ReplaceSelectionWithText(newText);
+			
+			DocumentLine line = this.Document.GetLineByNumber(this.Caret.Line);
+			this.IndentationStrategy.OnLineChanged(this.Document, line, newText);
 		}
 		
 		internal ISegment[] GetDeletableSegments(ISegment segment)

--- a/ICSharpCode.AvalonEdit/Indentation/CSharp/CSharpIndentationStrategy.cs
+++ b/ICSharpCode.AvalonEdit/Indentation/CSharp/CSharpIndentationStrategy.cs
@@ -91,5 +91,15 @@ namespace ICSharpCode.AvalonEdit.Indentation.CSharp
 		{
 			Indent(new TextDocumentAccessor(document, beginLine, endLine), true);
 		}
+		
+		/// <inheritdoc cref="IIndentationStrategy.OnLineChanged"/>
+		public override void OnLineChanged(TextDocument document, DocumentLine line, string newText)
+		{
+			// Reformat line when blocks are created
+			if (newText == "{" || newText == "}")
+			{
+				IndentLine(document, line);
+			}
+		}
 	}
 }

--- a/ICSharpCode.AvalonEdit/Indentation/DefaultIndentationStrategy.cs
+++ b/ICSharpCode.AvalonEdit/Indentation/DefaultIndentationStrategy.cs
@@ -53,5 +53,10 @@ namespace ICSharpCode.AvalonEdit.Indentation
 		public virtual void IndentLines(TextDocument document, int beginLine, int endLine)
 		{
 		}
+		
+		/// <inheritdoc/>
+		public virtual void OnLineChanged(TextDocument document, DocumentLine line, string newText)
+		{
+		}
 	}
 }

--- a/ICSharpCode.AvalonEdit/Indentation/IIndentationStrategy.cs
+++ b/ICSharpCode.AvalonEdit/Indentation/IIndentationStrategy.cs
@@ -36,5 +36,13 @@ namespace ICSharpCode.AvalonEdit.Indentation
 		/// Reindents a set of lines.
 		/// </summary>
 		void IndentLines(TextDocument document, int beginLine, int endLine);
+		
+		/// <summary>
+		/// Allows the indentation strategy to act based upon the used entering new text.
+		/// </summary>
+		/// <example>
+		/// This allows indentation change when {/} block characters are entered (C#)
+		/// </example>
+		void OnLineChanged(TextDocument document, DocumentLine line, string newText);
 	}
 }


### PR DESCRIPTION
This commit has been for a while in our fork.
Would this make sense to have this upstream so that we could switch back to NuGet version?