### PR TITLE
Fix System.InvalidOperationException: This Visual is not connected to…

### DIFF
--- a/ICSharpCode.AvalonEdit/CodeCompletion/CompletionWindowBase.cs
+++ b/ICSharpCode.AvalonEdit/CodeCompletion/CompletionWindowBase.cs
@@ -332,6 +332,9 @@ namespace ICSharpCode.AvalonEdit.CodeCompletion
 		protected void UpdatePosition()
 		{
 			TextView textView = this.TextArea.TextView;
+			if (PresentationSource.FromVisual(textView) == null)
+				return;
+			
 			// PointToScreen returns device dependent units (physical pixels)
 			Point location = textView.PointToScreen(visualLocation - textView.ScrollOffset);
 			Point locationTop = textView.PointToScreen(visualLocationTop - textView.ScrollOffset);


### PR DESCRIPTION
Check that TextView in PresentationSource


```
> System.InvalidOperationException: This Visual is not connected to a PresentationSource.
>     System.Windows.Media.Visual.PointToScreen(Point point)
>     ICSharpCode.AvalonEdit.CodeCompletion.CompletionWindowBase.UpdatePosition()
>     ICSharpCode.AvalonEdit.CodeCompletion.CompletionWindowBase.SetPosition(TextViewPosition position)
>     ICSharpCode.AvalonEdit.CodeCompletion.CompletionWindowBase.OnSourceInitialized(EventArgs e)
>    ICSharpCode.AvalonEdit.CodeCompletion.SharpDevelopCompletionWindow.OnSourceInitialized(EventArgs e)
>     System.Windows.Window.CreateSourceWindow(Boolean duringShow)
>     System.Windows.Window.ShowHelper(Object booleanBox)
>     ICSharpCode.AvalonEdit.CodeCompletion.CodeCompletionEditorAdapter.<>c__DisplayClass2.b__1()
>     System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
>     System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
```
