### PR TITLE
Fix/deserialization

### DIFF
--- a/ICSharpCode.AvalonEdit.Tests/Highlighting/DeserializationTests.cs
+++ b/ICSharpCode.AvalonEdit.Tests/Highlighting/DeserializationTests.cs
@@ -1,0 +1,32 @@
+﻿using ICSharpCode.AvalonEdit.Document;
+using ICSharpCode.AvalonEdit.Highlighting;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+
+namespace ICSharpCode.AvalonEdit.Tests.Highlighting
+{
+	[TestFixture]
+	public class DeserializationTests
+	{
+		TextDocument document;
+		DocumentHighlighter highlighter;
+
+		[SetUp]
+		public void SetUp()
+		{
+			document = new TextDocument("using System.Text;\n\tstring text = SomeMethod();");
+			highlighter = new DocumentHighlighter(document, HighlightingManager.Instance.GetDefinition("C#"));
+		}
+
+		[Test]
+		public void TestRoundTripColor()
+		{
+			HighlightingColor color = highlighter.GetNamedColor("Comment");
+			string jsonString = JsonConvert.SerializeObject(color);
+
+			HighlightingColor color2 = JsonConvert.DeserializeObject<HighlightingColor>(jsonString);
+			Assert.AreEqual(color, color2);
+		}
+	}
+}

--- a/ICSharpCode.AvalonEdit.Tests/ICSharpCode.AvalonEdit.Tests.csproj
+++ b/ICSharpCode.AvalonEdit.Tests/ICSharpCode.AvalonEdit.Tests.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>

--- a/ICSharpCode.AvalonEdit/Highlighting/HighlightingColor.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/HighlightingColor.cs
@@ -222,6 +222,7 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 			info.AddValue("HasUnderline", this.Underline.HasValue);
 			if (this.Underline.HasValue)
 				info.AddValue("Underline", this.Underline.Value);
+			info.AddValue("HasStrikethrough", this.Strikethrough.HasValue);
 			if (this.Strikethrough.HasValue)
 				info.AddValue("Strikethrough", this.Strikethrough.Value);
 			info.AddValue("Foreground", this.Foreground);

--- a/ICSharpCode.AvalonEdit/Highlighting/HighlightingColor.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/HighlightingColor.cs
@@ -196,8 +196,8 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 				this.Underline = info.GetBoolean("Underline");
 			if (info.GetBoolean("HasStrikethrough"))
 				this.Strikethrough = info.GetBoolean("Strikethrough");
-			this.Foreground = (HighlightingBrush)info.GetValue("Foreground", typeof(HighlightingBrush));
-			this.Background = (HighlightingBrush)info.GetValue("Background", typeof(HighlightingBrush));
+			this.Foreground = (HighlightingBrush)info.GetValue("Foreground", typeof(SimpleHighlightingBrush));
+			this.Background = (HighlightingBrush)info.GetValue("Background", typeof(SimpleHighlightingBrush));
 			if (info.GetBoolean("HasFamily"))
 				this.FontFamily = new FontFamily(info.GetString("Family"));
 			if (info.GetBoolean("HasSize"))


### PR DESCRIPTION
I found that round-tripping to store and back of `HighlightingColor`s was failing for two reasons:

1. The property `HasStrikethrough` was not being written, but was expected to be read.
2. The deserialization code was attempting to instantiate the abstract class `HighlightingBrush`. Fixed by instantiating `SimpleHighlightingBrush` instead.

This PR was developed by TDD: the test involves importing NewtonSoft.Json in the test project only. If you don't want to take that dependency then you are welcome to cherry-pick the code changes.

Fixes #208