### PR TITLE
Fix ArgumentNullException issue.

### DIFF
--- a/ICSharpCode.AvalonEdit/Search/SearchPanel.cs
+++ b/ICSharpCode.AvalonEdit/Search/SearchPanel.cs
@@ -272,10 +272,15 @@ namespace ICSharpCode.AvalonEdit.Search
 		{
 			if (searchTextBox == null)
 				return;
+
 			var be = searchTextBox.GetBindingExpression(TextBox.TextProperty);
+
 			try {
-				Validation.ClearInvalid(be);
+				if (be != null)
+					Validation.ClearInvalid(be);
+
 				UpdateSearch();
+
 			} catch (SearchPatternException ex) {
 				var ve = new ValidationError(be.ParentBinding.ValidationRules[0], be, ex.Message, ex);
 				Validation.MarkInvalid(be, ve);


### PR DESCRIPTION
How to reproduce?
1. Use the following xaml to custom `SearchPanel`.
2. Select any words then press `ctrl` + `f` to search first time.
3. Press `esc` or click close button of `SearchPanel` to close it.
4. Select any words then press `ctrl` + `f` again. Done, it throw `ArgumentNullException`.

![a0dfgPEjAP](https://user-images.githubusercontent.com/4510984/75090162-1e9b2f80-559b-11ea-9e94-df08708dccb3.gif)

```xaml
<avalonedit:TextEditor x:Name="PacTextEditor"
                       HorizontalScrollBarVisibility="Auto"
                       VerticalScrollBarVisibility="Auto"
                       ShowLineNumbers="True"
                       SyntaxHighlighting="JavaScript"
                       WordWrap="True"
                       ... >
    <avalonedit:TextEditor.Resources>
        <Style TargetType="search:SearchPanel" 
               BasedOn="{StaticResource {x:Type search:SearchPanel}}">
            <Setter Property="Template">
                <Setter.Value>
                    <ControlTemplate>
                        <Border Background="{DynamicResource WhiteBrush}"
                                BorderBrush="{DynamicResource TextBoxBorderBrush}"
                                BorderThickness="1"
                                HorizontalAlignment="Right"
                                VerticalAlignment="Top"
                                Cursor="Arrow">
                            <StackPanel Orientation="Horizontal">
                                <TextBox Name="PART_searchTextBox"
                                         Focusable="True"
                                         Width="150"
                                         Height="24"
                                         Margin="3">
                                    <TextBox.Text>
                                        <Binding Path="SearchPattern"
                                                 RelativeSource="{RelativeSource TemplatedParent}"
                                                 UpdateSourceTrigger="PropertyChanged">
                                            <Binding.ValidationRules>
                                                <ExceptionValidationRule />
                                            </Binding.ValidationRules>
                                        </Binding>
                                    </TextBox.Text>
                                </TextBox>
                                <search:DropDownButton Height="24" Width="18">
                                    <search:DropDownButton.DropDownContent>
                                        <Popup StaysOpen="False" Name="PART_dropdownPopup">
                                            <Border Background="{DynamicResource WhiteBrush}"
                                                    BorderBrush="{DynamicResource TextBoxBorderBrush}"
                                                    BorderThickness="1" Padding="1">
                                                <StackPanel>
                                                    <CheckBox IsChecked="{Binding MatchCase, RelativeSource={RelativeSource TemplatedParent}}"
                                                                Content="Match Case"
                                                                Margin="3" />
                                                    <CheckBox IsChecked="{Binding WholeWords, RelativeSource={RelativeSource TemplatedParent}}"
                                                                Content="Match Whole Words"
                                                                Margin="3" />
                                                    <CheckBox IsChecked="{Binding UseRegex, RelativeSource={RelativeSource TemplatedParent}}"
                                                                Content="Use Regular Expressions"
                                                                Margin="3" />
                                                </StackPanel>
                                            </Border>
                                        </Popup>
                                    </search:DropDownButton.DropDownContent>
                                </search:DropDownButton>
                                <Button Margin="1 3" Width="24" Height="24" Padding="0" 
                                        Content="{icons:Modern Kind=ArrowUp, Width=8}"
                                        Command="search:SearchCommands.FindPrevious" />
                                <Button Margin="1 3" Height="24" Width="24" Padding="0" 
                                        Content="{icons:Modern Kind=ArrowDown, Width=8}" 
                                        Command="search:SearchCommands.FindNext" />
                                <Button Margin="3" Height="24" Width="24" Padding="0" Focusable="False" 
                                        Content="{icons:Modern Kind=Close, Width=8}"
                                        Command="search:SearchCommands.CloseSearchPanel" />
                            </StackPanel>
                        </Border>
                    </ControlTemplate>
                </Setter.Value>
            </Setter>
        </Style>
    </avalonedit:TextEditor.Resources>
</avalonedit:TextEditor>
```