### PR TITLE
Fix null-reference exception in TextAreaAutomationPeer

### DIFF
--- a/ICSharpCode.AvalonEdit/Editing/TextAreaAutomationPeer.cs
+++ b/ICSharpCode.AvalonEdit/Editing/TextAreaAutomationPeer.cs
@@ -114,8 +114,11 @@ namespace ICSharpCode.AvalonEdit.Editing
 				return this;
 			if (patternInterface == PatternInterface.Scroll) {
 				TextEditor editor = TextArea.GetService(typeof(TextEditor)) as TextEditor;
-				if (editor != null)
-					return FromElement(editor).GetPattern(patternInterface);
+				if (editor != null) {
+					var fromElement = FromElement(editor);
+					if (fromElement != null)
+						fromElement.GetPattern(patternInterface);
+				}
 			}
 			return base.GetPattern(patternInterface);
 		}

--- a/ICSharpCode.AvalonEdit/Editing/TextAreaAutomationPeer.cs
+++ b/ICSharpCode.AvalonEdit/Editing/TextAreaAutomationPeer.cs
@@ -117,7 +117,7 @@ namespace ICSharpCode.AvalonEdit.Editing
 				if (editor != null) {
 					var fromElement = FromElement(editor);
 					if (fromElement != null)
-						fromElement.GetPattern(patternInterface);
+						return fromElement.GetPattern(patternInterface);
 				}
 			}
 			return base.GetPattern(patternInterface);


### PR DESCRIPTION
Fix null-reference exception in TextAreaAutomationPeer - that was randomly occurring in the application.