### PR TITLE
Prevent null reference exception when rendering

### DIFF
--- a/ICSharpCode.AvalonEdit/Folding/FoldingMarginMarker.cs
+++ b/ICSharpCode.AvalonEdit/Folding/FoldingMarginMarker.cs
@@ -68,6 +68,9 @@ namespace ICSharpCode.AvalonEdit.Folding
 		protected override void OnRender(DrawingContext drawingContext)
 		{
 			FoldingMargin margin = VisualParent as FoldingMargin;
+			if (margin == null) {
+				return;
+			}
 			Pen activePen = new Pen(margin.SelectedFoldingMarkerBrush, 1);
 			Pen inactivePen = new Pen(margin.FoldingMarkerBrush, 1);
 			activePen.StartLineCap = inactivePen.StartLineCap = PenLineCap.Square;


### PR DESCRIPTION
While investigating https://github.com/snoopwpf/snoopwpf/issues/28 i noticed that there is a missing null check in AvalonEdit.
The proposed change prevents that kind of issue.