### PR TITLE
Fixes for block select slowness and jumping caret issues

### DIFF
--- a/ICSharpCode.AvalonEdit/Editing/RectangleSelection.cs
+++ b/ICSharpCode.AvalonEdit/Editing/RectangleSelection.cs
@@ -331,7 +331,10 @@ namespace ICSharpCode.AvalonEdit.Editing
 					pos = new TextViewPosition(document.GetLocation(editOffset + firstInsertionLength));
 					textArea.ClearSelection();
 				}
-				textArea.Caret.Position = textArea.TextView.GetPosition(new Point(GetXPos(textArea, pos), textArea.TextView.GetVisualTopByDocumentLine(Math.Max(startLine, endLine)))).GetValueOrDefault();
+				TextViewPosition? calculatedPositon = textArea.TextView.GetPosition(new Point(GetXPos(textArea, pos), textArea.TextView.GetVisualTopByDocumentLine(Math.Max(startLine, endLine))));
+				if (calculatedPositon != null) {
+					textArea.Caret.Position = calculatedPositon.GetValueOrDefault();
+				}
 			}
 		}
 

--- a/ICSharpCode.AvalonEdit/Editing/TextArea.cs
+++ b/ICSharpCode.AvalonEdit/Editing/TextArea.cs
@@ -317,7 +317,10 @@ namespace ICSharpCode.AvalonEdit.Editing
 		void OnDocumentChanged(DocumentChangeEventArgs e)
 		{
 			caret.OnDocumentChanged(e);
-			this.Selection = selection.UpdateOnDocumentChange(e);
+
+			if (! (selection is RectangleSelection)) {
+				this.Selection = selection.UpdateOnDocumentChange(e);
+			}
 		}
 
 		void OnUpdateStarted()


### PR DESCRIPTION
This pull request has two fixes in it. The first, in RectangleSelection.cs, fixes an issue where the caret would jump to the top in some large block selections (especially if they were out of the visual). It would set the caret to the default value of a nullable, which put it at the top. This doesn't overwrite the caret position if it's null.

The next fix is a major one, that's been plaguing me for years at this point. Block selections seemed to get exponentially slower based on selection size. A large selection of a few hundred lines would take noticeably a few seconds per character typed. I tracked this down to the `OnDocumentChanged` event in TextArea.cs. Basically, every key press would trigger the event, which would trigger the event on the selection. This meant that every key press would cause a _lot_ of calculating and rendering for every sub-selection within the rectangular selection. By not calling this extra update event for rectangular selections I have been able to do thousands of lines in a selection with no issue. This change has been live in my application for months with no visible side effects.