### PR TITLE
Fix TSQL highlighting where a backslash exists before a single quote literal ('') in a string

### DIFF
--- a/ICSharpCode.AvalonEdit/Highlighting/Resources/TSQL-Mode.xshd
+++ b/ICSharpCode.AvalonEdit/Highlighting/Resources/TSQL-Mode.xshd
@@ -30,9 +30,6 @@
 		<Span color="Char">
 			<Begin>'</Begin>
 			<End>'</End>
-			<RuleSet>
-				<Span begin="\\" end="."/>
-			</RuleSet>
 		</Span>
 
 		<Keywords color="Keywords">


### PR DESCRIPTION
https://github.com/icsharpcode/AvalonEdit/issues/324

TSQL doesn't use \ as an escape character for strings.