### PR TITLE
Fix RichText ToHtml stack overflow, corruption, and CSS.

### DIFF
--- a/ICSharpCode.AvalonEdit.Tests/Highlighting/RichTextTests.cs
+++ b/ICSharpCode.AvalonEdit.Tests/Highlighting/RichTextTests.cs
@@ -16,6 +16,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System.Windows;
+using System.Windows.Media;
+
 using NUnit.Framework;
 
 namespace ICSharpCode.AvalonEdit.Highlighting
@@ -38,6 +41,18 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 			Assert.AreEqual(text1.GetHighlightingAt(0), text3.GetHighlightingAt(0));
 			Assert.AreNotEqual(text1.GetHighlightingAt(0), text3.GetHighlightingAt(5));
 			Assert.AreEqual(text2.GetHighlightingAt(0), text3.GetHighlightingAt(5));
+		}
+
+		[Test]
+		public void ToHtmlTest()
+		{
+			var textModel = new RichTextModel();
+			textModel.SetBackground(5, 3, new SimpleHighlightingBrush(Colors.Yellow));
+			textModel.SetForeground(9, 6, new SimpleHighlightingBrush(Colors.Blue));
+			textModel.SetFontWeight(15, 1, FontWeights.Bold);
+			var text = new RichText("This has spaces!", textModel);
+			var html = text.ToHtml(new HtmlOptions());
+			Assert.AreEqual("This&nbsp;<span style=\"background-color: #ffff00; \">has</span>&nbsp;<span style=\"color: #0000ff; \">spaces</span><span style=\"font-weight: bold; \">!</span>", html);
 		}
 	}
 }

--- a/ICSharpCode.AvalonEdit/Highlighting/HighlightingColor.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/HighlightingColor.cs
@@ -248,6 +248,12 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 					b.AppendFormat(CultureInfo.InvariantCulture, "color: #{0:x2}{1:x2}{2:x2}; ", c.Value.R, c.Value.G, c.Value.B);
 				}
 			}
+			if (Background != null) {
+				Color? c = Background.GetColor(null);
+				if (c != null) {
+					b.AppendFormat(CultureInfo.InvariantCulture, "background-color: #{0:x2}{1:x2}{2:x2}; ", c.Value.R, c.Value.G, c.Value.B);
+				}
+			}
 			if (FontWeight != null) {
 				b.Append("font-weight: ");
 				b.Append(FontWeight.Value.ToString().ToLowerInvariant());

--- a/ICSharpCode.AvalonEdit/Highlighting/HtmlRichTextWriter.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/HtmlRichTextWriter.cs
@@ -158,7 +158,7 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 				}
 				if (endPos > pos)
 					WriteSimpleString(value.Substring(pos, endPos - pos));
-				WriteChar(value[pos]);
+				WriteChar(value[endPos]);
 				pos = endPos + 1;
 			} while (pos < value.Length);
 		}

--- a/ICSharpCode.AvalonEdit/Utils/RichTextWriter.cs
+++ b/ICSharpCode.AvalonEdit/Utils/RichTextWriter.cs
@@ -56,10 +56,9 @@ namespace ICSharpCode.AvalonEdit.Utils
 			// If we just call Write(richText.Text.Substring(...)) below, then the C# compiler invokes
 			// the non-virtual Write(RichText) method due to RichText's implicit conversion from string.
 			// That leads to an immediate, unconditional StackOverflowException!
-			TextWriter textWriter = this;
 			foreach (var section in richText.GetHighlightedSections(offset, length)) {
 				BeginSpan(section.Color);
-				textWriter.Write(richText.Text.Substring(section.Offset, section.Length));
+				((TextWriter)this).Write(richText.Text.Substring(section.Offset, section.Length));
 				EndSpan();
 			}
 		}

--- a/ICSharpCode.AvalonEdit/Utils/RichTextWriter.cs
+++ b/ICSharpCode.AvalonEdit/Utils/RichTextWriter.cs
@@ -52,9 +52,14 @@ namespace ICSharpCode.AvalonEdit.Utils
 		/// </summary>
 		public virtual void Write(RichText richText, int offset, int length)
 		{
+			// We have to use a TextWriter reference to invoke the virtual Write(string) method.
+			// If we just call Write(richText.Text.Substring(...)) below, then the C# compiler invokes
+			// the non-virtual Write(RichText) method due to RichText's implicit conversion from string.
+			// That leads to an immediate, unconditional StackOverflowException!
+			TextWriter textWriter = this;
 			foreach (var section in richText.GetHighlightedSections(offset, length)) {
 				BeginSpan(section.Color);
-				Write(richText.Text.Substring(section.Offset, section.Length));
+				textWriter.Write(richText.Text.Substring(section.Offset, section.Length));
 				EndSpan();
 			}
 		}


### PR DESCRIPTION
`RichTextWriter.Write(RichText, int, int)` caused an immediate, unconditional StackOverflowException because it called the non-virtual `Write(RichText)` method due to RichText's implicit string conversion. I fixed this by invoking the virtual `Write(string)` method through a base TextWriter reference instead.

That revealed a bug in the derived class's virtual Write implementation. `HtmlRichTextWriter.Write(string)` incorrectly wrote the first char instead of the last/split char when ending the output. So, an input like "Oh, my!" would output as "Oh,Omy!".

Then I discovered that the `HighlightingColor.ToCss()` method omitted the background-color style because it ignored the `HighlightingColor.Background` property. I implemented that similar to the Foreground support.

I added the `RichTextTests.ToHtmlTest()` method to make sure these code paths keep working. They must not have been used before due to the unconditional StackOverflowException and mangled output. However, the ToHtml support is useful in my new [RegExponent](https://github.com/menees/RegExponent) utility for testing regular expressions. It uses AvalonEdit for syntax highlighting and for generating HTML code for regex patterns, replacements, and input matches. I hope to release RegExponent soon, but it would be nice if these fixes can be merged into a new AvalonEdit NuGet release first.