### PR TITLE
Fix PixelsPerDip warning (requires .NET 4.6.2+).

### DIFF
--- a/ICSharpCode.AvalonEdit/Utils/TextFormatterFactory.cs
+++ b/ICSharpCode.AvalonEdit/Utils/TextFormatterFactory.cs
@@ -78,7 +78,8 @@ namespace ICSharpCode.AvalonEdit.Utils
 				emSize.Value,
 				foreground,
 				null,
-				TextOptions.GetTextFormattingMode(element)
+				TextOptions.GetTextFormattingMode(element),
+				VisualTreeHelper.GetDpi(element).PixelsPerDip
 			);
 		}
 	}


### PR DESCRIPTION
Now that .NET 4.6.2 is required (per f115e94d129b2485803281a3423ecd6f536fb9e9), here's a simple fix for the obsolete `FormattedText` constructor warning:

```
warning CS0618: 'FormattedText.FormattedText(string, CultureInfo, FlowDirection, Typeface, double, Brush, NumberSubstitution, TextFormattingMode)' is obsolete: 'Use the PixelsPerDip override'
```

I pass in PixelsPerDip using the recommendation from https://stackoverflow.com/a/45766452/1882616.