### PR TITLE
ICSharpCode is a reserved prefix now, switch AvalonEdit to use it

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -74,7 +74,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: AvalonEdit NuGet Package (${{ matrix.configuration }})
-        path: ICSharpCode.AvalonEdit/bin/Release/AvalonEdit*.nupkg
+        path: ICSharpCode.AvalonEdit/bin/Release/ICSharpCode.AvalonEdit*.nupkg
         if-no-files-found: error      
 
     - name: Upload Snupkg Artifact
@@ -82,10 +82,10 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: AvalonEdit Snupkg (${{ matrix.configuration }})
-        path: ICSharpCode.AvalonEdit/bin/Release/AvalonEdit*.snupkg
+        path: ICSharpCode.AvalonEdit/bin/Release/ICSharpCode.AvalonEdit*.snupkg
         if-no-files-found: error      
         
     - name: Publish NuGet
       if: github.ref == 'refs/heads/master' && matrix.configuration == 'release'
       run: |
-        dotnet nuget push "ICSharpCode.AvalonEdit\bin\Release\AvalonEdit*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/${{ github.repository_owner }}
+        dotnet nuget push "ICSharpCode.AvalonEdit\bin\Release\ICSharpCode.AvalonEdit*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/${{ github.repository_owner }}

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 Note: this changelog only lists major changes and fixes for major bugs. For a complete list of changes, see the git log.
 
 tbd: AvalonEdit X
+* Change PackageId from AvalonEdit to ICSharpCode.AvalonEdit (prefix reserved)
 * Change framework targets to .NET Framework 4.6.2, .NET Core 3.1 and .NET 6.0 (.NET Framework 4.0, 4.5 and .NET 5.0 removed)
 
 2021/12/28: AvalonEdit 6.1.3

--- a/ICSharpCode.AvalonEdit/ICSharpCode.AvalonEdit.csproj
+++ b/ICSharpCode.AvalonEdit/ICSharpCode.AvalonEdit.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageId>AvalonEdit</PackageId>
+    <PackageId>ICSharpCode.AvalonEdit</PackageId>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
ICSharpCode is now a reserved prefix https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation

We will follow the process at https://docs.microsoft.com/en-us/nuget/nuget-org/deprecate-packages#transfer-popularity-to-a-newer-package to transfer popularity to the new package.

On publishing, change README to reflect new NuGet package.