### PR TITLE
Bug fix

### DIFF
--- a/ICSharpCode.AvalonEdit/Rendering/TextView.cs
+++ b/ICSharpCode.AvalonEdit/Rendering/TextView.cs
@@ -1264,7 +1264,7 @@ namespace ICSharpCode.AvalonEdit.Rendering
 							}
 						}
 						startVC = element.VisualColumn;
-						length = element.DocumentLength;
+						length = element.VisualLength;
 						currentBrush = element.BackgroundBrush;
 					} else {
 						length += element.VisualLength;


### PR DESCRIPTION
A tab has two characters when set to show tabs, so you must use `VisualLength`.