### PR TITLE
Assign tooltip variable to ToolTip object of FrameworkElement to fix a bug that styling could not applied to the Tooltip.

### DIFF
--- a/ICSharpCode.AvalonEdit/CodeCompletion/CompletionWindow.cs
+++ b/ICSharpCode.AvalonEdit/CodeCompletion/CompletionWindow.cs
@@ -60,6 +60,8 @@ namespace ICSharpCode.AvalonEdit.CodeCompletion
 			toolTip.PlacementTarget = this;
 			toolTip.Placement = PlacementMode.Right;
 			toolTip.Closed += toolTip_Closed;
+			// assign to FrameworkElement ToolTip to allow styling
+			ToolTip = toolTip;
 
 			AttachEvents();
 		}


### PR DESCRIPTION
Assign tooltip variable to ToolTip object of FrameworkElement so that the tooltip can be styled. Previously it was not part of the WPF visual tree of the containing Window.