### PR TITLE
Prioritize longer keywords also when they're not alphanumeric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ bld/
 # Visual Studio 2017 auto generated files
 Generated\ Files/
 
+# JetBrains Rider
+.idea/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/ICSharpCode.AvalonEdit.Tests/Highlighting/XmlHighlightingDefinitionTests.cs
+++ b/ICSharpCode.AvalonEdit.Tests/Highlighting/XmlHighlightingDefinitionTests.cs
@@ -1,0 +1,39 @@
+﻿using System.Linq;
+
+using ICSharpCode.AvalonEdit.Document;
+using ICSharpCode.AvalonEdit.Highlighting;
+using ICSharpCode.AvalonEdit.Highlighting.Xshd;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.AvalonEdit.Tests.Highlighting
+{
+	[TestFixture]
+	public class XmlHighlightingDefinitionTests
+	{
+		[Test]
+		public void LongerKeywordsArePreferred()
+		{
+			var color = new XshdColor { Name = "Result" };
+			var syntaxDefinition = new XshdSyntaxDefinition {
+				Elements = {
+					color,
+					new XshdRuleSet {
+						Elements = { new XshdKeywords {
+								ColorReference = new XshdReference<XshdColor>(null, color.Name),
+								Words = { "foo", "foo.bar." }
+							}
+						}
+					}
+				}
+			};
+
+			var document = new TextDocument("This is a foo.bar. keyword");
+			var highlighter = new DocumentHighlighter(document, new XmlHighlightingDefinition(syntaxDefinition, HighlightingManager.Instance));
+			var result = highlighter.HighlightLine(1);
+
+			var highlightedText = document.GetText(result.Sections.Single());
+			Assert.That(highlightedText, Is.EqualTo("foo.bar."));
+		}
+	}
+}

--- a/ICSharpCode.AvalonEdit/Highlighting/Xshd/XmlHighlightingDefinition.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/Xshd/XmlHighlightingDefinition.cs
@@ -240,9 +240,9 @@ namespace ICSharpCode.AvalonEdit.Highlighting.Xshd
 					}
 					keyWordRegex.Append(@")\b");
 				} else {
-					keyWordRegex.Append('(');
+					keyWordRegex.Append("(?>");
 					int i = 0;
-					foreach (string keyword in keywords.Words) {
+					foreach (string keyword in keywords.Words.OrderByDescending(w => w.Length)) {
 						if (i++ > 0)
 							keyWordRegex.Append('|');
 						if (char.IsLetterOrDigit(keyword[0]))


### PR DESCRIPTION
I noticed the following issue in ILSpy:

![image](https://user-images.githubusercontent.com/7913492/221372403-eabca871-82e9-4d7c-93f6-fca48219bf80.png)

Note that `clt` is highlighted instead of `clt.un`.

This PR fixes this by making sure longer keywords are always preferred. Currently, this logic is only applied if every keyword in the list starts and ends with an alphanumeric character.
