### PR TITLE
Overwrite registered highlightings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ bld/
 # Visual Studio 2017 auto generated files
 Generated\ Files/
 
+# JetBrains Rider
+.idea/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/ICSharpCode.AvalonEdit.Tests/Highlighting/HighlightingManagerTests.cs
+++ b/ICSharpCode.AvalonEdit.Tests/Highlighting/HighlightingManagerTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+using ICSharpCode.AvalonEdit.Highlighting;
+using ICSharpCode.AvalonEdit.Highlighting.Xshd;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.AvalonEdit.Tests.Highlighting
+{
+	[TestFixture]
+	public class HighlightingManagerTests
+	{
+		[Test]
+		public void OverwriteHighlightingDefinitionWithSameName()
+		{
+			var highlightingManager = new HighlightingManager();
+
+			var definitionA = CreateDefinition("TestDefinition");
+			var definitionB = CreateDefinition("TestDefinition");
+			var definitionC = CreateDefinition("DifferentName");
+
+			Assert.That(highlightingManager.HighlightingDefinitions, Is.Empty);
+
+			highlightingManager.RegisterHighlighting(definitionA.Name, Array.Empty<string>(), definitionA);
+			Assert.That(highlightingManager.HighlightingDefinitions, Is.EqualTo(new[] { definitionA }));
+
+			highlightingManager.RegisterHighlighting(definitionB.Name, Array.Empty<string>(), definitionB);
+			Assert.That(highlightingManager.HighlightingDefinitions, Is.EqualTo(new[] { definitionB }));
+
+			highlightingManager.RegisterHighlighting(definitionC.Name, Array.Empty<string>(), definitionC);
+			Assert.That(highlightingManager.HighlightingDefinitions, Is.EqualTo(new[] { definitionB, definitionC }));
+
+			XmlHighlightingDefinition CreateDefinition(string name)
+			{
+				return new XmlHighlightingDefinition(new XshdSyntaxDefinition { Name = name, Elements = { new XshdRuleSet() } }, highlightingManager);
+			}
+		}
+	}
+}

--- a/ICSharpCode.AvalonEdit/Highlighting/HighlightingManager.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/HighlightingManager.cs
@@ -185,8 +185,9 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 				throw new ArgumentNullException("highlighting");
 
 			lock (lockObj) {
-				allHighlightings.Add(highlighting);
 				if (name != null) {
+					if (highlightingsByName.TryGetValue(name, out var existingDefinition))
+						allHighlightings.Remove(existingDefinition);
 					highlightingsByName[name] = highlighting;
 				}
 				if (extensions != null) {
@@ -194,6 +195,7 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 						highlightingsByExtension[ext] = highlighting;
 					}
 				}
+				allHighlightings.Add(highlighting);
 			}
 		}
 


### PR DESCRIPTION
ILSpy changes themes by calling `HighlightingManager.RegisterHighlighting` to set the new color scheme: https://github.com/icsharpcode/ILSpy/blob/4ebe075e5859939463ae420446f024f10c3bf077/ILSpy/TextView/DecompilerTextView.cs#L1220-L1226

I noticed that each registered highlighting definition is added to the `HighlightingDefinitions` collection, and is never removed. Therefore, repeatedly changing the theme in ILSpy creates a small memory leak.

This PR changes this behavior so that registering a named highlighting definition will remove the previous one if it exists.
