### PR TITLE
Add support for custom link regexes via TextEditorOptions.

### DIFF
--- a/ICSharpCode.AvalonEdit.Tests/Rendering/LinkElementGeneratorTests.cs
+++ b/ICSharpCode.AvalonEdit.Tests/Rendering/LinkElementGeneratorTests.cs
@@ -1,0 +1,77 @@
+﻿using ICSharpCode.AvalonEdit.Document;
+using ICSharpCode.AvalonEdit.Rendering;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.AvalonEdit.Tests.Rendering
+{
+	[TestFixture]
+	[Apartment(System.Threading.ApartmentState.STA)]
+	public class LinkElementGeneratorTests
+	{
+		[Test]
+		public void ParsingOfCustomLinkRegexes()
+		{
+			var linkElementGenerator = new LinkElementGenerator();
+			const string link = "example://mylink";
+			const string input = "Visit " + link + " please";
+			var textSource = GetTextSource(input);
+			linkElementGenerator.StartGeneration(textSource);
+
+			var interestedOffsetBeforeCustomRegex = linkElementGenerator.GetFirstInterestedOffset(0);
+			Assert.That(interestedOffsetBeforeCustomRegex, Is.EqualTo(-1));
+
+			var optionsWithCustomLink = new TextEditorOptions {
+				// Check for example:// protocol instead of http:// protocol.
+				LinkRegex = @"\bexample://\w+\b",
+			};
+			((IBuiltinElementGenerator)linkElementGenerator).FetchOptions(optionsWithCustomLink);
+
+			var interestedOffsetAfterCustomRegex = linkElementGenerator.GetFirstInterestedOffset(0);
+			var expectedOffset = input.IndexOf(link);
+			Assert.That(interestedOffsetAfterCustomRegex, Is.EqualTo(expectedOffset));
+
+			linkElementGenerator.FinishGeneration();
+		}
+
+		[Test]
+		public void ParsingOfCustomMailRegexes()
+		{
+			var linkElementGenerator = new MailLinkElementGenerator();
+			const string link = "example@example.verylongtld";
+			const string input = "Email " + link + " please";
+			var textSource = GetTextSource(input);
+			linkElementGenerator.StartGeneration(textSource);
+
+			var interestedOffsetBeforeCustomRegex = linkElementGenerator.GetFirstInterestedOffset(0);
+			Assert.That(interestedOffsetBeforeCustomRegex, Is.EqualTo(-1));
+
+			var optionsWithCustomLink = new TextEditorOptions {
+				// The same as the default except that TLDs can be up to 12 chars now.
+				MailRegex = @"\b[\w\d\.\-]+\@[\w\d\.\-]+\.[a-z]{2,12}\b",
+			};
+			((IBuiltinElementGenerator)linkElementGenerator).FetchOptions(optionsWithCustomLink);
+
+			var interestedOffsetAfterCustomRegex = linkElementGenerator.GetFirstInterestedOffset(0);
+			var expectedOffset = input.IndexOf(link);
+			Assert.That(interestedOffsetAfterCustomRegex, Is.EqualTo(expectedOffset));
+
+			linkElementGenerator.FinishGeneration();
+		}
+
+		private static VisualLineTextSource GetTextSource(string input)
+		{
+			var textDocument = new TextDocument(input);
+			var textView = new TextView {
+				Document = textDocument,
+			};
+			var documentLine = textDocument.Lines[0];
+			var visualLine = textView.GetOrConstructVisualLine(documentLine);
+			var textSource = new VisualLineTextSource(visualLine) {
+				Document = textDocument,
+				TextView = textView,
+			};
+			return textSource;
+		}
+	}
+}

--- a/ICSharpCode.AvalonEdit/Rendering/LinkElementGenerator.cs
+++ b/ICSharpCode.AvalonEdit/Rendering/LinkElementGenerator.cs
@@ -41,7 +41,10 @@ namespace ICSharpCode.AvalonEdit.Rendering
 		// try to detect email addresses
 		internal readonly static Regex defaultMailRegex = new Regex(@"\b[\w\d\.\-]+\@[\w\d\.\-]+\.[a-z]{2,6}\b");
 
-		readonly Regex linkRegex;
+		/// <summary>
+		/// The regex used to parse the type of link this class represents.
+		/// </summary>
+		protected Regex linkRegex;
 
 		/// <summary>
 		/// Gets/Sets whether the user needs to press Control to click the link.
@@ -71,6 +74,7 @@ namespace ICSharpCode.AvalonEdit.Rendering
 		void IBuiltinElementGenerator.FetchOptions(TextEditorOptions options)
 		{
 			this.RequireControlModifierForClick = options.RequireControlModifierForHyperlinkClick;
+			this.linkRegex = new Regex(options.LinkRegex);
 		}
 
 		Match GetMatch(int startOffset, out int matchOffset)
@@ -142,7 +146,7 @@ namespace ICSharpCode.AvalonEdit.Rendering
 	/// This element generator can be easily enabled and configured using the
 	/// <see cref="TextEditorOptions"/>.
 	/// </remarks>
-	sealed class MailLinkElementGenerator : LinkElementGenerator
+	sealed class MailLinkElementGenerator : LinkElementGenerator, IBuiltinElementGenerator
 	{
 		/// <summary>
 		/// Creates a new MailLinkElementGenerator.
@@ -150,6 +154,12 @@ namespace ICSharpCode.AvalonEdit.Rendering
 		public MailLinkElementGenerator()
 			: base(defaultMailRegex)
 		{
+		}
+
+		void IBuiltinElementGenerator.FetchOptions(TextEditorOptions options)
+		{
+			this.RequireControlModifierForClick = options.RequireControlModifierForHyperlinkClick;
+			this.linkRegex = new Regex(options.MailRegex);
 		}
 
 		protected override Uri GetUriFromMatch(Match match)

--- a/ICSharpCode.AvalonEdit/TextEditorOptions.cs
+++ b/ICSharpCode.AvalonEdit/TextEditorOptions.cs
@@ -19,6 +19,9 @@
 using System;
 using System.ComponentModel;
 using System.Reflection;
+using System.Text.RegularExpressions;
+
+using ICSharpCode.AvalonEdit.Rendering;
 
 namespace ICSharpCode.AvalonEdit
 {
@@ -166,6 +169,20 @@ namespace ICSharpCode.AvalonEdit
 			}
 		}
 
+		string linkRegex = LinkElementGenerator.defaultLinkRegex.ToString();
+		/// <summary>
+		/// Gets/Sets the regex used to parse hyperlinks.
+		/// </summary>
+		public virtual string LinkRegex {
+			get { return linkRegex; }
+			set {
+				if (!Equals(linkRegex, value)) {
+					linkRegex = value;
+					OnPropertyChanged(nameof(LinkRegex));
+				}
+			}
+		}
+
 		bool enableEmailHyperlinks = true;
 
 		/// <summary>
@@ -179,6 +196,20 @@ namespace ICSharpCode.AvalonEdit
 				if (enableEmailHyperlinks != value) {
 					enableEmailHyperlinks = value;
 					OnPropertyChanged("EnableEMailHyperlinks");
+				}
+			}
+		}
+
+		string mailRegex = LinkElementGenerator.defaultMailRegex.ToString();
+		/// <summary>
+		/// Gets/Sets the regex used to parse mail hyperlinks.
+		/// </summary>
+		public virtual string MailRegex {
+			get { return mailRegex; }
+			set {
+				if (!Equals(mailRegex, value)) {
+					mailRegex = value;
+					OnPropertyChanged(nameof(MailRegex));
 				}
 			}
 		}


### PR DESCRIPTION
My use-case is that I would like hyperlinks to be able to have semicolons and commas in and still parse.

During the implementation of this PR, I realised that there is another extensibility point, subclassing `LinkElementGenerator` and then adding it to the `TextView.ElementGenerators` collection, but I found this hard to discover without first digging into the code, and I think there's still potentially value in exposing this property more easily via `TextEditorOptions`. That being said, I can understand if you don't want to accept the PR as a result of this.