### PR TITLE
Enable code folding in more than one TextView / Improve scroll speed during mouse selection

### DIFF
--- a/ICSharpCode.AvalonEdit/Editing/SelectionMouseHandler.cs
+++ b/ICSharpCode.AvalonEdit/Editing/SelectionMouseHandler.cs
@@ -650,7 +650,7 @@ namespace ICSharpCode.AvalonEdit.Editing
 						textArea.Caret.Offset = Math.Max(newWord.EndOffset, startWord.EndOffset);
 				}
 			}
-			textArea.Caret.BringCaretToView(5.0);
+			textArea.Caret.BringCaretToView(textArea.Options.MinimumDistanceToViewBorder);
 		}
 		#endregion
 

--- a/ICSharpCode.AvalonEdit/Folding/FoldingManager.cs
+++ b/ICSharpCode.AvalonEdit/Folding/FoldingManager.cs
@@ -55,6 +55,14 @@ namespace ICSharpCode.AvalonEdit.Folding
 		}
 		#endregion
 
+		/// <summary>
+		/// Adds another text view to the same document
+		/// </summary>
+		public void AddTextView(TextView textView)
+		{
+			textViews.Add(textView);
+		}
+
 		#region ReceiveWeakEvent
 		/// <inheritdoc cref="IWeakEventListener.ReceiveWeakEvent"/>
 		protected virtual bool ReceiveWeakEvent(Type managerType, object sender, EventArgs e)

--- a/ICSharpCode.AvalonEdit/Rendering/TextView.cs
+++ b/ICSharpCode.AvalonEdit/Rendering/TextView.cs
@@ -994,6 +994,21 @@ namespace ICSharpCode.AvalonEdit.Rendering
 			while (yPos < availableSize.Height && nextLine != null) {
 				VisualLine visualLine = GetVisualLine(nextLine.LineNumber);
 				if (visualLine == null) {
+					
+					// Don't build visual lines from collapsed lines
+					var bBreakAll = false;
+					while (heightTree.GetIsCollapsed(nextLine.LineNumber)) {
+						if (nextLine.NextLine != null)
+							nextLine = nextLine.NextLine;
+						else {
+							bBreakAll = true;
+							break;
+						}
+					}
+					
+					if (bBreakAll)
+						break;
+					
 					visualLine = BuildVisualLine(nextLine,
 												 globalTextRunProperties, paragraphProperties,
 												 elementGeneratorsArray, lineTransformersArray,

--- a/ICSharpCode.AvalonEdit/TextEditorOptions.cs
+++ b/ICSharpCode.AvalonEdit/TextEditorOptions.cs
@@ -492,5 +492,21 @@ namespace ICSharpCode.AvalonEdit
 				}
 			}
 		}
+
+		double minimumDistanceToViewBorder = 5.0;
+
+		/// <summary>
+		/// Gets/Sets the minimum distance to the view border.
+		/// </summary>
+		[DefaultValue(5.0)]
+		public double MinimumDistanceToViewBorder {
+			get { return minimumDistanceToViewBorder; }
+			set {
+				if (Math.Abs(minimumDistanceToViewBorder - value) >= 1e-6) {
+					minimumDistanceToViewBorder = value;
+					OnPropertyChanged("MinimumDistanceToViewBorder");
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
1. Enable code folding in more than one TextView using the same TextDocument. This can be used to implement a code navigation view to the same document on the right side.

2. Define MinimumDistanceToViewBorder as an option to improve scroll speed during mouse selection. A higher value than the default 5.0, e.g. 30 or 50, should speed up scrolling during a mouse selection with a move over the last visual line. 