### PR TITLE
Make HighlightingRule extensible so rules aren't required to use Regex

### DIFF
--- a/ICSharpCode.AvalonEdit/Highlighting/HighlightingRuleSet.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/HighlightingRuleSet.cs
@@ -35,7 +35,7 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 		public HighlightingRuleSet()
 		{
 			this.Spans = new NullSafeCollection<HighlightingSpan>();
-			this.Rules = new NullSafeCollection<HighlightingRule>();
+			this.Rules = new NullSafeCollection<IHighlightingRule>();
 		}
 
 		/// <summary>
@@ -51,7 +51,7 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 		/// <summary>
 		/// Gets the list of rules.
 		/// </summary>
-		public IList<HighlightingRule> Rules { get; private set; }
+		public IList<IHighlightingRule> Rules { get; private set; }
 
 		/// <inheritdoc/>
 		public override string ToString()

--- a/ICSharpCode.AvalonEdit/Highlighting/HighlightingSpan.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/HighlightingSpan.cs
@@ -70,6 +70,28 @@ namespace ICSharpCode.AvalonEdit.Highlighting
 		/// </summary>
 		public bool SpanColorIncludesEnd { get; set; }
 
+		/// <summary>
+		/// Gets the match from the specified position using the <see cref="StartExpression"/> regex.
+		/// </summary>
+		/// <param name="text">The string to search for a match</param>
+		/// <param name="position">The zero-based character position at which to start the search</param>
+		/// <returns>And object that contains information about the match</returns>
+		public RuleMatch GetStartMatch(string text, int position)
+		{
+			return RuleMatch.FromRegexMatch(StartExpression.Match(text, position));
+		}
+
+		/// <summary>
+		/// Gets the match from the specified position using the <see cref="EndExpression"/> regex.
+		/// </summary>
+		/// <param name="text">The string to search for a match</param>
+		/// <param name="position">The zero-based character position at which to start the search</param>
+		/// <returns>And object that contains information about the match</returns>
+		public RuleMatch GetEndMatch(string text, int position)
+		{
+			return RuleMatch.FromRegexMatch(EndExpression.Match(text, position));
+		}
+
 		/// <inheritdoc/>
 		public override string ToString()
 		{

--- a/ICSharpCode.AvalonEdit/Highlighting/IHighlightingRule.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/IHighlightingRule.cs
@@ -16,40 +16,32 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System;
-using System.Text.RegularExpressions;
-
 namespace ICSharpCode.AvalonEdit.Highlighting
 {
 	/// <summary>
-	/// A highlighting rule.
+	/// Interface of a highlighting rule
 	/// </summary>
-	[Serializable]
-	public class HighlightingRule : IHighlightingRule
+	public interface IHighlightingRule
 	{
 		/// <summary>
-		/// Gets/Sets the regular expression for the rule.
+		/// Gets the first match for the rule
 		/// </summary>
-		public Regex Regex { get; set; }
+		/// <param name="input">The string to search for a match.</param>
+		/// <param name="beginning">The zero-based character position in the input string that defines the leftmost 
+		/// position to be searched.</param>
+		/// <param name="length">The number of characters in the substring to include in the search.</param>
+		/// <param name="lineNumber">The line number of the <paramref name="input"/> string.</param>
+		/// <returns>An object that contains information about the match.</returns>
+		RuleMatch GetMatch(string input, int beginning, int length, int lineNumber);
 
 		/// <summary>
-		/// Gets/Sets the highlighting color.
+		/// Gets the highlighting color.
 		/// </summary>
-		public HighlightingColor Color { get; set; }
+		HighlightingColor Color { get; }
 
-		/// <inheritdoc/>
-		public string RuleInfo => $"Regex: {Regex}";
-
-		/// <inheritdoc/>
-		public RuleMatch GetMatch(string input, int beginning, int length, int lineNumber)
-		{
-			return RuleMatch.FromRegexMatch(Regex.Match(input, beginning, length));
-		}
-
-		/// <inheritdoc/>
-		public override string ToString()
-		{
-			return "[" + GetType().Name + " " + Regex + "]";
-		}
+		/// <summary>
+		/// Info about rule. Used to help figure out why rule failed
+		/// </summary>
+		string RuleInfo { get; }
 	}
 }

--- a/ICSharpCode.AvalonEdit/Highlighting/RuleMatch.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/RuleMatch.cs
@@ -16,40 +16,47 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System;
 using System.Text.RegularExpressions;
 
 namespace ICSharpCode.AvalonEdit.Highlighting
 {
 	/// <summary>
-	/// A highlighting rule.
+	/// And object that contains information about a rule's match
 	/// </summary>
-	[Serializable]
-	public class HighlightingRule : IHighlightingRule
+	public class RuleMatch
 	{
 		/// <summary>
-		/// Gets/Sets the regular expression for the rule.
+		/// Creates a new RuleMatch instance.
 		/// </summary>
-		public Regex Regex { get; set; }
+		public RuleMatch() { }
 
 		/// <summary>
-		/// Gets/Sets the highlighting color.
+		/// Gets a value indicating whether the match was successful.
 		/// </summary>
-		public HighlightingColor Color { get; set; }
+		public bool Success { get; set; }
 
-		/// <inheritdoc/>
-		public string RuleInfo => $"Regex: {Regex}";
+		/// <summary>
+		/// The position in the original string where the first character of captured substring was found.
+		/// </summary>
+		public int Index { get; set; }
 
-		/// <inheritdoc/>
-		public RuleMatch GetMatch(string input, int beginning, int length, int lineNumber)
+		/// <summary>
+		/// The length of the captured substring.
+		/// </summary>
+		public int Length { get; set; }
+
+		/// <summary>
+		/// Creates a new RuleMatch instance from a <see cref="Match"/> instance.
+		/// </summary>
+		/// <param name="match">Match to use</param>
+		/// <returns>RuleMatch instance built from match parameter</returns>
+		public static RuleMatch FromRegexMatch(Match match)
 		{
-			return RuleMatch.FromRegexMatch(Regex.Match(input, beginning, length));
-		}
-
-		/// <inheritdoc/>
-		public override string ToString()
-		{
-			return "[" + GetType().Name + " " + Regex + "]";
+			return new RuleMatch() {
+				Success = match.Success,
+				Index = match.Index,
+				Length = match.Length,
+			};
 		}
 	}
 }

--- a/ICSharpCode.AvalonEdit/Highlighting/Xshd/XmlHighlightingDefinition.cs
+++ b/ICSharpCode.AvalonEdit/Highlighting/Xshd/XmlHighlightingDefinition.cs
@@ -172,7 +172,7 @@ namespace ICSharpCode.AvalonEdit.Highlighting.Xshd
 						if (span != null) {
 							rs.Spans.Add(span);
 						} else {
-							HighlightingRule elementRule = o as HighlightingRule;
+							IHighlightingRule elementRule = o as IHighlightingRule;
 							if (elementRule != null) {
 								rs.Rules.Add(elementRule);
 							}


### PR DESCRIPTION
Added `IHighlightingRule` so developers can implement custom rules that don't use a simple regex pattern. As part of this, I had to make a simple `RuleMatch` type to replace the uses of `System.Text.RegularExpressions.Match` instances as I needed a way for a custom implmentation to still return match results.

Here's an example of a custom `IHighlightingRule` I needed: https://gist.github.com/GSonofNun/f5a97b24bb9d57c06c723a7bc02940a0
This rule allows me to highlight delimiter separated values, giving a color to each column of values, and even lets me change the font weight and underline of certain lines.
<img width="513" alt="image" src="https://github.com/icsharpcode/AvalonEdit/assets/3924712/a3336ec6-8f22-4596-bbec-854111afb0d8">

I think these changes greatly expands the scope of possibilities for HighlightingRules.