### PR TITLE
Add support for runtimes without built-in COM interop

### DIFF
--- a/ICSharpCode.AvalonEdit/Editing/ImeNativeWrapper.cs
+++ b/ICSharpCode.AvalonEdit/Editing/ImeNativeWrapper.cs
@@ -116,7 +116,14 @@ namespace ICSharpCode.AvalonEdit.Editing
 		{
 			if (!textFrameworkThreadMgrInitialized) {
 				textFrameworkThreadMgrInitialized = true;
-				TF_CreateThreadMgr(out textFrameworkThreadMgr);
+				try
+				{
+					TF_CreateThreadMgr(out textFrameworkThreadMgr);
+				}
+				catch
+				{
+					// The call will fail if the current runtime doesn't have COM interop
+				}
 			}
 			return textFrameworkThreadMgr;
 		}


### PR DESCRIPTION
Unfortunately the built-in COM interop can't really be enabled for non-Windows platforms, we can't even stub `TF_CreateThreadMgr` on our side - .NET Runtime simply refused to call it.

This PR enables IME support for *nix platforms:

https://github.com/icsharpcode/AvalonEdit/assets/1067584/e68afb5b-1100-492f-890e-7a1eedebd35e





