### PR TITLE
[fix] Get right Column when use custom element replace text content.

### DIFF
--- a/ICSharpCode.AvalonEdit/Rendering/VisualLine.cs
+++ b/ICSharpCode.AvalonEdit/Rendering/VisualLine.cs
@@ -470,6 +470,9 @@ namespace ICSharpCode.AvalonEdit.Rendering
 		{
 			var textLine = GetTextLineByVisualYPosition(point.Y);
 			int vc = GetVisualColumn(textLine, point.X, allowVirtualSpace);
+			// Not matter how many columns the generated element originally occupies.it is only considered a single column.
+			// so need recalculate column 
+			vc = GetVisualColumn(vc);
 			isAtEndOfLine = (vc >= GetTextLineVisualStartColumn(textLine) + textLine.Length);
 			return vc;
 		}


### PR DESCRIPTION
If you want to use custom elements replace text content.
example: I want to use custom elements to change some keywords by using the menu, button or other elements for my special feature.
you will get the wrong caret position when you click textview .
because GetVisualColumn doesn't calculate generator elements. so need to recalculate the column.
this PR can fix #416 
