### PR TITLE
Fix JSON highlighting

### DIFF
--- a/ICSharpCode.AvalonEdit/Highlighting/Resources/Json.xshd
+++ b/ICSharpCode.AvalonEdit/Highlighting/Resources/Json.xshd
@@ -10,7 +10,7 @@
 	<Color name="Punctuation" foreground="Black" />
 
 	<RuleSet name="String">
-		<Span begin="\\" end="."/>
+		<Span begin="\\" end="." />
 	</RuleSet>
 
 	<RuleSet name="Object">
@@ -22,27 +22,28 @@
 			<Begin>'</Begin>
 			<End>'</End>
 		</Span>
-		<Span color="Punctuation" ruleSet="Expression">
+		<Span color="Punctuation" ruleSet="Expression" multiline="true">
 			<Begin>:</Begin>
+			<End>(?= [,}] )</End>
 		</Span>
-		<Span color="Punctuation">
-			<Begin>,</Begin>
-		</Span>
+		<Rule color="Punctuation">
+			,
+		</Rule>
 	</RuleSet>
 
 	<RuleSet name="Array">
-		<Import ruleSet="Expression"/>
-		<Span color="Punctuation">
-			<Begin>,</Begin>
-		</Span>
+		<Import ruleSet="Expression" />
+		<Rule color="Punctuation">
+			,
+		</Rule>
 	</RuleSet>
 
 	<RuleSet name="Expression">
-		<Keywords color="Bool" >
+		<Keywords color="Bool">
 			<Word>true</Word>
 			<Word>false</Word>
 		</Keywords>
-		<Keywords color="Null" >
+		<Keywords color="Null">
 			<Word>null</Word>
 		</Keywords>
 		<Span color="String" ruleSet="String">
@@ -62,11 +63,22 @@
 			<End>\]</End>
 		</Span>
 		<Rule color="Number">
-			\b0[xX][0-9a-fA-F]+|(\b\d+(\.[0-9]+)?|\.[0-9]+)([eE][+-]?[0-9]+)?
+			-? \b
+			(?:
+				0[xX][0-9a-fA-F]+
+				|
+				(?:
+
+					[0-9]+ (?: \. [0-9]+ )?
+					|
+					\. [0-9]+
+				)
+				(?: [eE] [+-]? [0-9]+ )?
+			)
 		</Rule>
 	</RuleSet>
 
 	<RuleSet>
-		<Import ruleSet="Expression"/>
+		<Import ruleSet="Expression" />
 	</RuleSet>
 </SyntaxDefinition>


### PR DESCRIPTION
While doing https://github.com/icsharpcode/ILSpy/pull/3138 I noticed the JSON highlighting was wrong (see the last 2 lines in the screenshot), so this PR fixes that.

EDIT: I noticed there's an issue for this, so this fixes #410.

Here's the difference for the following example:

```json
{
    "String": "Value",
    "Bool": true,
    "Null": null,
    "Number:": -42e10,
    "Object": {
        "Foo:": "Bar",
        "Multiline Key"
            :
            "Value"
    },
    "Array": ["Foo", "Bar", "Baz"]
}
```

Before:

![image](https://github.com/icsharpcode/AvalonEdit/assets/7913492/4be01727-f4d9-4ac8-a012-3ecf1a6b97b8)

After:

![image](https://github.com/icsharpcode/AvalonEdit/assets/7913492/cb050185-d5e1-4ecf-9b41-81f0b60e813f)

The rule for numbers adds support for `-` and reformats the regex.

I also kept the existing single-quoted strings and hex numbers which are not part of the JSON spec.