### PR TITLE
Fix rounding error when getting VisualLine

### DIFF
--- a/ICSharpCode.AvalonEdit/Rendering/TextView.cs
+++ b/ICSharpCode.AvalonEdit/Rendering/TextView.cs
@@ -1743,10 +1743,12 @@ namespace ICSharpCode.AvalonEdit.Rendering
 			// TODO: change this method to also work outside the visible range -
 			// required to make GetPosition work as expected!
 			EnsureVisualLines();
+
+			double epsilon = 1e-12; // Small margin to prevent rounding problems, Double.Epsilon is not a large enough margin.
 			foreach (VisualLine vl in this.VisualLines) {
-				if (visualTop < vl.VisualTop)
+				if (visualTop < vl.VisualTop - epsilon)
 					continue;
-				if (visualTop < vl.VisualTop + vl.Height)
+				if (visualTop < vl.VisualTop + vl.Height - epsilon)
 					return vl;
 			}
 			return null;


### PR DESCRIPTION
A rounding error occasionally occurs here (found when using RectangleSelect), causing this method to unexpectedly return null, which in turn causes RectangleSelection.ReplaceSelectionWithText() to incorrectly set textArea.Caret.Position to (Line = 1, Column = 1).

Note that the epsilon value of 1e-12 is an estimation based on the accuracy of the visualTop value, which has 13 decimals when its integer value is in the thousands (4 digits). 