### PR TITLE
Fix: Rectangular selection ignores scroll offset

### DIFF
--- a/ICSharpCode.AvalonEdit/Rendering/BackgroundGeometryBuilder.cs
+++ b/ICSharpCode.AvalonEdit/Rendering/BackgroundGeometryBuilder.cs
@@ -261,6 +261,9 @@ namespace ICSharpCode.AvalonEdit.Rendering
 					} else {
 						right = visualLine.GetTextLineVisualXPosition(lastTextLine, segmentEndVC);
 					}
+
+					left -= scrollOffset.X;
+					right -= scrollOffset.X;
 					Rect extendSelection = new Rect(Math.Min(left, right), y, Math.Abs(right - left), line.Height);
 					if (!lastRect.IsEmpty) {
 						if (extendSelection.IntersectsWith(lastRect)) {


### PR DESCRIPTION
An `AvaloniaEdit` user has discovered a problem with rectangular selection when virtual space is enabled. See https://github.com/AvaloniaUI/AvaloniaEdit/issues/472.

I provided a fix for `AvaloniaEdit`: https://github.com/AvaloniaUI/AvaloniaEdit/pull/496

`AvalonEdit` shows the same problem. This PR implements the fix for `AvalonEdit`.

Details: 
When a selection extends beyond the visual line into the "virtual space" then the `BackgroundGeometryBuilder` creates two segments per line. One for the visible text, and one for the virtual space.

The segment for the virtual space didn't apply the scroll offset. This is now fixed.